### PR TITLE
feat: add Deno LSP client

### DIFF
--- a/src/lsp_client/capability/build.py
+++ b/src/lsp_client/capability/build.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 from lsp_client.protocol import (
+    ExperimentalCapabilityProtocol,
     GeneralCapabilityProtocol,
     NotebookCapabilityProtocol,
     ServerRequestHookProtocol,
@@ -22,6 +23,7 @@ def build_client_capabilities(cls: type) -> lsp_type.ClientCapabilities:
     )
     window = lsp_type.WindowClientCapabilities()
     general = lsp_type.GeneralClientCapabilities()
+    experimental: dict[str, Any] = {}
 
     if issubclass(cls, WorkspaceCapabilityProtocol):
         cls.register_workspace_capability(workspace)
@@ -33,6 +35,8 @@ def build_client_capabilities(cls: type) -> lsp_type.ClientCapabilities:
         cls.register_window_capability(window)
     if issubclass(cls, GeneralCapabilityProtocol):
         cls.register_general_capability(general)
+    if issubclass(cls, ExperimentalCapabilityProtocol):
+        cls.register_experimental_capability(experimental)
 
     return lsp_type.ClientCapabilities(
         workspace=workspace,
@@ -40,6 +44,7 @@ def build_client_capabilities(cls: type) -> lsp_type.ClientCapabilities:
         notebook_document=notebook_document,
         window=window,
         general=general,
+        experimental=experimental if experimental else None,
     )
 
 

--- a/src/lsp_client/capability/build.py
+++ b/src/lsp_client/capability/build.py
@@ -44,7 +44,7 @@ def build_client_capabilities(cls: type) -> lsp_type.ClientCapabilities:
         notebook_document=notebook_document,
         window=window,
         general=general,
-        experimental=experimental if experimental else None,
+        experimental=experimental or None,
     )
 
 

--- a/src/lsp_client/clients/deno/README.md
+++ b/src/lsp_client/clients/deno/README.md
@@ -1,0 +1,39 @@
+# Deno LSP Custom Capabilities
+
+This document summarizes the custom LSP capabilities and protocol extensions provided by the Deno Language Server.
+
+## Custom Requests (Client → Server)
+
+| Request                       | Purpose                                                                                                                   |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `deno/cache`                  | Instructs Deno to cache a module and its dependencies. Usually sent as a response to a code action for un-cached modules. |
+| `deno/performance`            | Requests timing averages for Deno's internal instrumentation for monitoring and debugging.                                |
+| `deno/reloadImportRegistries` | Reloads cached responses from import registries.                                                                          |
+| `deno/virtualTextDocument`    | Requests read-only virtual text documents (e.g., cached remote modules or Deno library files) using the `deno:` schema.   |
+| `deno/task`                   | Retrieves a list of available Deno tasks defined in `deno.json` or `deno.jsonc`.                                          |
+
+## Custom Notifications (Server → Client)
+
+| Notification         | Purpose                                                                                                      |
+| -------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `deno/registryState` | Notifies the client about import registry discovery status, providing suggestions for configuration updates. |
+
+## Testing API (Experimental)
+
+Requires `experimental.testingApi` capability to be enabled by both client and server.
+
+### Requests (Client → Server)
+
+- `deno/testRun`: Initiates a test execution for specified modules or tests.
+- `deno/testRunCancel`: Cancels an ongoing test run by ID.
+
+### Notifications (Server → Client)
+
+- `deno/testModule`: Sent when a test module is discovered.
+- `deno/testModuleDelete`: Sent when a test module is deleted.
+- `deno/testRunProgress`: Tracks the progress and state of a test run (`enqueued`, `started`, `passed`, `failed`, etc.).
+
+## Other Experimental Capabilities
+
+- `denoConfigTasks`: Support for tasks defined in Deno configuration files.
+- `didRefreshDenoConfigurationTreeNotifications`: Notifications for when the configuration tree is refreshed.

--- a/src/lsp_client/clients/deno/README.md
+++ b/src/lsp_client/clients/deno/README.md
@@ -4,19 +4,19 @@ This document summarizes the custom LSP capabilities and protocol extensions pro
 
 ## Custom Requests (Client → Server)
 
-| Request                       | Purpose                                                                                                                   |
-| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| `deno/cache`                  | Instructs Deno to cache a module and its dependencies. Usually sent as a response to a code action for un-cached modules. |
-| `deno/performance`            | Requests timing averages for Deno's internal instrumentation for monitoring and debugging.                                |
-| `deno/reloadImportRegistries` | Reloads cached responses from import registries.                                                                          |
-| `deno/virtualTextDocument`    | Requests read-only virtual text documents (e.g., cached remote modules or Deno library files) using the `deno:` schema.   |
-| `deno/task`                   | Retrieves a list of available Deno tasks defined in `deno.json` or `deno.jsonc`.                                          |
+| Request                       | Python Method                           | Purpose                                                                                                                   |
+| ----------------------------- | --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `deno/cache`                  | `request_deno_cache`                    | Instructs Deno to cache a module and its dependencies. Usually sent as a response to a code action for un-cached modules. |
+| `deno/performance`            | `request_deno_performance`              | Requests timing averages for Deno's internal instrumentation for monitoring and debugging.                                |
+| `deno/reloadImportRegistries` | `request_deno_reload_import_registries` | Reloads cached responses from import registries.                                                                          |
+| `deno/virtualTextDocument`    | `request_deno_virtual_text_document`    | Requests read-only virtual text documents (e.g., cached remote modules or Deno library files) using the `deno:` schema.   |
+| `deno/task`                   | `request_deno_task`                     | Retrieves a list of available Deno tasks defined in `deno.json` or `deno.jsonc`.                                          |
 
 ## Custom Notifications (Server → Client)
 
-| Notification         | Purpose                                                                                                      |
-| -------------------- | ------------------------------------------------------------------------------------------------------------ |
-| `deno/registryState` | Notifies the client about import registry discovery status, providing suggestions for configuration updates. |
+| Notification         | Python Method                 | Default Behavior                                                                   |
+| -------------------- | ----------------------------- | ---------------------------------------------------------------------------------- |
+| `deno/registryState` | `receive_deno_registry_state` | Logs the registry discovery status and configuration suggestions at `DEBUG` level. |
 
 ## Testing API (Experimental)
 
@@ -24,16 +24,33 @@ Requires `experimental.testingApi` capability to be enabled by both client and s
 
 ### Requests (Client → Server)
 
-- `deno/testRun`: Initiates a test execution for specified modules or tests.
-- `deno/testRunCancel`: Cancels an ongoing test run by ID.
+| Request              | Python Method                  | Purpose                                                    |
+| -------------------- | ------------------------------ | ---------------------------------------------------------- |
+| `deno/testRun`       | `request_deno_test_run`        | Initiates a test execution for specified modules or tests. |
+| `deno/testRunCancel` | `request_deno_test_run_cancel` | Cancels an ongoing test run by ID.                         |
 
 ### Notifications (Server → Client)
 
-- `deno/testModule`: Sent when a test module is discovered.
-- `deno/testModuleDelete`: Sent when a test module is deleted.
-- `deno/testRunProgress`: Tracks the progress and state of a test run (`enqueued`, `started`, `passed`, `failed`, etc.).
+| Notification            | Python Method                     | Default Behavior                                                                           |
+| ----------------------- | --------------------------------- | ------------------------------------------------------------------------------------------ |
+| `deno/testModule`       | `receive_deno_test_module`        | Logs discovered test module information at `DEBUG` level.                                  |
+| `deno/testModuleDelete` | `receive_deno_test_module_delete` | Logs deleted test module information at `DEBUG` level.                                     |
+| `deno/testRunProgress`  | `receive_deno_test_run_progress`  | Logs test run state (`enqueued`, `started`, `passed`, etc.) and progress at `DEBUG` level. |
 
 ## Other Experimental Capabilities
 
 - `denoConfigTasks`: Support for tasks defined in Deno configuration files.
 - `didRefreshDenoConfigurationTreeNotifications`: Notifications for when the configuration tree is refreshed.
+
+## Deno LSP Documentation
+
+### Official Documentation
+
+- [Language Server Integration](https://docs.deno.com/runtime/reference/lsp_integration/) - Comprehensive guide for integrating with Deno's LSP, including custom capabilities and testing API
+- [deno lsp CLI Reference](https://docs.deno.com/runtime/reference/cli/lsp/) - Basic information about the `deno lsp` subcommand
+- [Deno & Visual Studio Code](https://docs.deno.com/runtime/reference/vscode/) - Complete integration guide and setup
+
+### Source Code & Development
+
+- [Deno CLI LSP Source](https://github.com/denoland/deno/tree/main/cli/lsp) - The actual LSP implementation in Rust
+- [VS Code Extension](https://github.com/denoland/vscode_deno) - Official VS Code extension source code

--- a/src/lsp_client/clients/deno/__init__.py
+++ b/src/lsp_client/clients/deno/__init__.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from .client import DenoClient, DenoDockerServer, DenoLocalServer
+
+__all__ = [
+    "DenoClient",
+    "DenoDockerServer",
+    "DenoLocalServer",
+]

--- a/src/lsp_client/clients/deno/__init__.py
+++ b/src/lsp_client/clients/deno/__init__.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-from .client import DenoClient, DenoDockerServer, DenoLocalServer
+from .client import DenoClient, DenoContainerServer
 
 __all__ = [
     "DenoClient",
-    "DenoDockerServer",
-    "DenoLocalServer",
+    "DenoContainerServer",
 ]

--- a/src/lsp_client/clients/deno/client.py
+++ b/src/lsp_client/clients/deno/client.py
@@ -28,6 +28,20 @@ from lsp_client.server.docker import DockerServer
 from lsp_client.server.local import LocalServer
 from lsp_client.utils.types import lsp_type
 
+from .extension import (
+    WithReceiveDenoRegistryStatus,
+    WithReceiveDenoTestModule,
+    WithReceiveDenoTestModuleDelete,
+    WithReceiveDenoTestRunProgress,
+    WithRequestDenoCache,
+    WithRequestDenoPerformance,
+    WithRequestDenoReloadImportRegistries,
+    WithRequestDenoTask,
+    WithRequestDenoTestRun,
+    WithRequestDenoTestRunCancel,
+    WithRequestDenoVirtualTextDocument,
+)
+
 DenoLocalServer = partial(LocalServer, command=["deno", "lsp"])
 DenoDockerServer = partial(DockerServer, image="lspcontainers/denols:2.4.2")
 
@@ -45,6 +59,17 @@ class DenoClient(
     WithRequestWorkspaceSymbol,
     WithReceiveLogMessage,
     WithReceivePublishDiagnostics,
+    WithRequestDenoCache,
+    WithRequestDenoPerformance,
+    WithRequestDenoReloadImportRegistries,
+    WithRequestDenoVirtualTextDocument,
+    WithRequestDenoTask,
+    WithRequestDenoTestRun,
+    WithRequestDenoTestRunCancel,
+    WithReceiveDenoRegistryStatus,
+    WithReceiveDenoTestModule,
+    WithReceiveDenoTestModuleDelete,
+    WithReceiveDenoTestRunProgress,
 ):
     """
     - Language: TypeScript, JavaScript

--- a/src/lsp_client/clients/deno/client.py
+++ b/src/lsp_client/clients/deno/client.py
@@ -24,7 +24,8 @@ from lsp_client.capability.server_notification import (
 )
 from lsp_client.capability.server_notification.log_message import WithReceiveLogMessage
 from lsp_client.client.abc import LSPClient
-from lsp_client.server.docker import DockerServer
+from lsp_client.server.abc import LSPServer
+from lsp_client.server.container import ContainerServer
 from lsp_client.server.local import LocalServer
 from lsp_client.utils.types import lsp_type
 
@@ -42,8 +43,9 @@ from .extension import (
     WithRequestDenoVirtualTextDocument,
 )
 
-DenoLocalServer = partial(LocalServer, command=["deno", "lsp"])
-DenoDockerServer = partial(DockerServer, image="lspcontainers/denols:2.4.2")
+DenoContainerServer = partial(
+    ContainerServer, image="ghcr.io/observerw/lsp-client/deno:latest"
+)
 
 
 @define
@@ -104,6 +106,10 @@ class DenoClient(
     @override
     def get_language_id(self) -> lsp_type.LanguageKind:
         return lsp_type.LanguageKind.TypeScript
+
+    @override
+    def create_default_server(self) -> LSPServer:
+        return LocalServer(command=["deno", "lsp"])
 
     @override
     def create_initialization_options(self) -> dict[str, Any]:

--- a/src/lsp_client/clients/deno/client.py
+++ b/src/lsp_client/clients/deno/client.py
@@ -155,11 +155,14 @@ class DenoClient(
         logger.warning("deno not found, attempting to install...")
 
         try:
-            await anyio.run_process(["npm", "install", "-g", "deno"])
-            logger.info("Successfully installed deno via npm")
+            await anyio.run_process(
+                ["sh", "-c", "curl -fsSL https://deno.land/install.sh | sh"]
+            )
+            logger.info("Successfully installed deno via shell script")
             return
         except CalledProcessError as e:
             raise RuntimeError(
-                "Could not install deno. Please install it manually with 'npm install -g deno'. "
+                "Could not install deno. Please install it manually with:\n"
+                "curl -fsSL https://deno.land/install.sh | sh\n\n"
                 "See https://deno.land/ for more information."
             ) from e

--- a/src/lsp_client/clients/deno/client.py
+++ b/src/lsp_client/clients/deno/client.py
@@ -155,6 +155,7 @@ class DenoClient(
         logger.warning("deno not found, attempting to install...")
 
         try:
+            # Use shell to execute the piped command
             await anyio.run_process(
                 ["sh", "-c", "curl -fsSL https://deno.land/install.sh | sh"]
             )

--- a/src/lsp_client/clients/deno/client.py
+++ b/src/lsp_client/clients/deno/client.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import shutil
+from functools import partial
+from subprocess import CalledProcessError
+from typing import Any, override
+
+import anyio
+from attrs import Factory, define
+from loguru import logger
+
+from lsp_client.capability.request import (
+    WithRequestCallHierarchy,
+    WithRequestDefinition,
+    WithRequestDocumentSymbol,
+    WithRequestHover,
+    WithRequestImplementation,
+    WithRequestReferences,
+    WithRequestTypeDefinition,
+    WithRequestWorkspaceSymbol,
+)
+from lsp_client.capability.server_notification import (
+    WithReceivePublishDiagnostics,
+)
+from lsp_client.capability.server_notification.log_message import WithReceiveLogMessage
+from lsp_client.client.abc import LSPClient
+from lsp_client.server.docker import DockerServer
+from lsp_client.server.local import LocalServer
+from lsp_client.utils.types import lsp_type
+
+DenoLocalServer = partial(LocalServer, command=["deno", "lsp"])
+DenoDockerServer = partial(DockerServer, image="lspcontainers/denols:2.4.2")
+
+
+@define
+class DenoClient(
+    LSPClient,
+    WithRequestHover,
+    WithRequestDefinition,
+    WithRequestReferences,
+    WithRequestImplementation,
+    WithRequestTypeDefinition,
+    WithRequestCallHierarchy,
+    WithRequestDocumentSymbol,
+    WithRequestWorkspaceSymbol,
+    WithReceiveLogMessage,
+    WithReceivePublishDiagnostics,
+):
+    """
+    - Language: TypeScript, JavaScript
+    - Homepage: https://deno.land/
+    - Doc: https://docs.deno.com/runtime/reference/lsp_integration/
+    - Github: https://github.com/denoland/deno
+    - VSCode Extension: https://marketplace.visualstudio.com/items?itemName=denoland.vscode-deno
+    """
+
+    enable: bool = True
+    unstable: bool = False
+    lint: bool = True
+
+    config: str | None = None
+    import_map: str | None = None
+
+    code_lens_implementations: bool = True
+    code_lens_references: bool = True
+    code_lens_references_all_functions: bool = True
+    code_lens_test: bool = True
+
+    suggest_complete_function_calls: bool = True
+    suggest_names: bool = True
+    suggest_paths: bool = True
+    suggest_auto_imports: bool = True
+    suggest_imports_auto_discover: bool = True
+    suggest_imports_hosts: list[str] = Factory(list)
+
+    testing_enable: bool = False
+    testing_args: list[str] = Factory(list)
+
+    @override
+    def get_language_id(self) -> lsp_type.LanguageKind:
+        return lsp_type.LanguageKind.TypeScript
+
+    @override
+    def create_initialization_options(self) -> dict[str, Any]:
+        options: dict[str, Any] = {
+            "enable": self.enable,
+            "unstable": self.unstable,
+            "lint": self.lint,
+            "codeLens": {
+                "implementations": self.code_lens_implementations,
+                "references": self.code_lens_references,
+                "referencesAllFunctions": self.code_lens_references_all_functions,
+                "test": self.code_lens_test,
+            },
+            "suggest": {
+                "completeFunctionCalls": self.suggest_complete_function_calls,
+                "names": self.suggest_names,
+                "paths": self.suggest_paths,
+                "autoImports": self.suggest_auto_imports,
+                "imports": {
+                    "autoDiscover": self.suggest_imports_auto_discover,
+                    "hosts": list(self.suggest_imports_hosts),
+                },
+            },
+        }
+
+        if self.config:
+            options["config"] = self.config
+
+        if self.import_map:
+            options["importMap"] = self.import_map
+
+        if self.testing_enable:
+            options["testing"] = {
+                "enable": self.testing_enable,
+                "args": list(self.testing_args),
+            }
+
+        return options
+
+    @override
+    def check_server_compatibility(self, info: lsp_type.ServerInfo | None) -> None:
+        return
+
+    @override
+    async def ensure_installed(self) -> None:
+        if shutil.which("deno"):
+            return
+
+        logger.warning("deno not found, attempting to install...")
+
+        try:
+            await anyio.run_process(["npm", "install", "-g", "deno"])
+            logger.info("Successfully installed deno via npm")
+            return
+        except CalledProcessError as e:
+            raise RuntimeError(
+                "Could not install deno. Please install it manually with 'npm install -g deno'. "
+                "See https://deno.land/ for more information."
+            ) from e

--- a/src/lsp_client/clients/deno/extension.py
+++ b/src/lsp_client/clients/deno/extension.py
@@ -1,17 +1,61 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import Protocol, override
+from typing import Any, Protocol, override, runtime_checkable
 
+from loguru import logger
+
+from lsp_client.jsonrpc.id import jsonrpc_uuid
 from lsp_client.protocol import (
     CapabilityClientProtocol,
     CapabilityProtocol,
+    ExperimentalCapabilityProtocol,
+    ServerNotificationHook,
     ServerRequestHookProtocol,
+    ServerRequestHookRegistry,
+)
+from lsp_client.utils.types import AnyPath, lsp_type
+
+from .models import (
+    DENO_CACHE,
+    DENO_PERFORMANCE,
+    DENO_REGISTRY_STATE,
+    DENO_RELOAD_IMPORT_REGISTRIES,
+    DENO_TASK,
+    DENO_TEST_MODULE,
+    DENO_TEST_MODULE_DELETE,
+    DENO_TEST_RUN,
+    DENO_TEST_RUN_CANCEL,
+    DENO_TEST_RUN_PROGRESS,
+    DENO_VIRTUAL_TEXT_DOCUMENT,
+    CacheParams,
+    CacheRequest,
+    CacheResponse,
+    PerformanceRequest,
+    PerformanceResponse,
+    RegistryStatusNotification,
+    ReloadImportRegistriesRequest,
+    ReloadImportRegistriesResponse,
+    TaskRequest,
+    TaskResponse,
+    TestModuleDeleteNotification,
+    TestModuleNotification,
+    TestRunCancelParams,
+    TestRunCancelRequest,
+    TestRunCancelResponse,
+    TestRunProgressNotification,
+    TestRunRequest,
+    TestRunRequestParams,
+    TestRunResponse,
+    TestRunResponseParams,
+    VirtualTextDocumentParams,
+    VirtualTextDocumentRequest,
+    VirtualTextDocumentResponse,
 )
 
 
-class WithDenoCacheRequest(
-    ServerRequestHookProtocol,
+@runtime_checkable
+class WithRequestDenoCache(
     CapabilityProtocol,
     CapabilityClientProtocol,
     Protocol,
@@ -19,4 +63,275 @@ class WithDenoCacheRequest(
     @override
     @classmethod
     def methods(cls) -> Sequence[str]:
-        return ("deno/cache",)
+        return (DENO_CACHE,)
+
+    async def request_deno_cache(
+        self,
+        referrer: AnyPath,
+        uris: Sequence[AnyPath] = (),
+    ) -> None:
+        return await self.request(
+            CacheRequest(
+                id=jsonrpc_uuid(),
+                params=CacheParams(
+                    referrer=lsp_type.TextDocumentIdentifier(uri=self.as_uri(referrer)),
+                    uris=[
+                        lsp_type.TextDocumentIdentifier(uri=self.as_uri(uri))
+                        for uri in uris
+                    ],
+                ),
+            ),
+            schema=CacheResponse,
+        )
+
+
+@runtime_checkable
+class WithRequestDenoPerformance(
+    CapabilityProtocol,
+    CapabilityClientProtocol,
+    Protocol,
+):
+    @override
+    @classmethod
+    def methods(cls) -> Sequence[str]:
+        return (DENO_PERFORMANCE,)
+
+    async def request_deno_performance(self) -> Any:
+        return await self.request(
+            PerformanceRequest(id=jsonrpc_uuid()),
+            schema=PerformanceResponse,
+        )
+
+
+@runtime_checkable
+class WithRequestDenoReloadImportRegistries(
+    CapabilityProtocol,
+    CapabilityClientProtocol,
+    Protocol,
+):
+    @override
+    @classmethod
+    def methods(cls) -> Sequence[str]:
+        return (DENO_RELOAD_IMPORT_REGISTRIES,)
+
+    async def request_deno_reload_import_registries(self) -> None:
+        return await self.request(
+            ReloadImportRegistriesRequest(id=jsonrpc_uuid()),
+            schema=ReloadImportRegistriesResponse,
+        )
+
+
+@runtime_checkable
+class WithRequestDenoVirtualTextDocument(
+    CapabilityProtocol,
+    CapabilityClientProtocol,
+    Protocol,
+):
+    @override
+    @classmethod
+    def methods(cls) -> Sequence[str]:
+        return (DENO_VIRTUAL_TEXT_DOCUMENT,)
+
+    async def request_deno_virtual_text_document(
+        self,
+        uri: str,
+    ) -> str:
+        return await self.request(
+            VirtualTextDocumentRequest(
+                id=jsonrpc_uuid(),
+                params=VirtualTextDocumentParams(
+                    text_document=lsp_type.TextDocumentIdentifier(uri=uri)
+                ),
+            ),
+            schema=VirtualTextDocumentResponse,
+        )
+
+
+@runtime_checkable
+class WithRequestDenoTask(
+    CapabilityProtocol,
+    CapabilityClientProtocol,
+    Protocol,
+):
+    @override
+    @classmethod
+    def methods(cls) -> Sequence[str]:
+        return (DENO_TASK,)
+
+    async def request_deno_task(self) -> list[Any]:
+        return await self.request(
+            TaskRequest(id=jsonrpc_uuid()),
+            schema=TaskResponse,
+        )
+
+
+@runtime_checkable
+class WithRequestDenoTestRun(
+    CapabilityProtocol,
+    CapabilityClientProtocol,
+    ExperimentalCapabilityProtocol,
+    Protocol,
+):
+    @override
+    @classmethod
+    def methods(cls) -> Sequence[str]:
+        return (DENO_TEST_RUN,)
+
+    @override
+    @classmethod
+    def register_experimental_capability(cls, cap: dict[str, Any]) -> None:
+        cap["testingApi"] = True
+
+    async def request_deno_test_run(
+        self,
+        params: TestRunRequestParams,
+    ) -> TestRunResponseParams:
+        return await self.request(
+            TestRunRequest(
+                id=jsonrpc_uuid(),
+                params=params,
+            ),
+            schema=TestRunResponse,
+        )
+
+
+@runtime_checkable
+class WithRequestDenoTestRunCancel(
+    CapabilityProtocol,
+    CapabilityClientProtocol,
+    Protocol,
+):
+    @override
+    @classmethod
+    def methods(cls) -> Sequence[str]:
+        return (DENO_TEST_RUN_CANCEL,)
+
+    async def request_deno_test_run_cancel(
+        self,
+        test_run_id: int,
+    ) -> None:
+        return await self.request(
+            TestRunCancelRequest(
+                id=jsonrpc_uuid(),
+                params=TestRunCancelParams(id=test_run_id),
+            ),
+            schema=TestRunCancelResponse,
+        )
+
+
+@runtime_checkable
+class WithReceiveDenoRegistryStatus(
+    ServerRequestHookProtocol,
+    CapabilityClientProtocol,
+    Protocol,
+):
+    @override
+    @classmethod
+    def methods(cls) -> Sequence[str]:
+        return (DENO_REGISTRY_STATE,)
+
+    async def receive_deno_registry_state(
+        self, noti: RegistryStatusNotification
+    ) -> None:
+        logger.debug("Received Deno registry state: {}", noti.params)
+
+    @override
+    def register_server_request_hooks(
+        self, registry: ServerRequestHookRegistry
+    ) -> None:
+        super().register_server_request_hooks(registry)
+        registry.register(
+            DENO_REGISTRY_STATE,
+            ServerNotificationHook(
+                cls=RegistryStatusNotification,
+                execute=self.receive_deno_registry_state,
+            ),
+        )
+
+
+@runtime_checkable
+class WithReceiveDenoTestModule(
+    ServerRequestHookProtocol,
+    CapabilityClientProtocol,
+    Protocol,
+):
+    @override
+    @classmethod
+    def methods(cls) -> Sequence[str]:
+        return (DENO_TEST_MODULE,)
+
+    async def receive_deno_test_module(self, noti: TestModuleNotification) -> None:
+        logger.debug("Received Deno test module: {}", noti.params)
+
+    @override
+    def register_server_request_hooks(
+        self, registry: ServerRequestHookRegistry
+    ) -> None:
+        super().register_server_request_hooks(registry)
+        registry.register(
+            DENO_TEST_MODULE,
+            ServerNotificationHook(
+                cls=TestModuleNotification,
+                execute=self.receive_deno_test_module,
+            ),
+        )
+
+
+@runtime_checkable
+class WithReceiveDenoTestModuleDelete(
+    ServerRequestHookProtocol,
+    CapabilityClientProtocol,
+    Protocol,
+):
+    @override
+    @classmethod
+    def methods(cls) -> Sequence[str]:
+        return (DENO_TEST_MODULE_DELETE,)
+
+    async def receive_deno_test_module_delete(
+        self, noti: TestModuleDeleteNotification
+    ) -> None:
+        logger.debug("Received Deno test module delete: {}", noti.params)
+
+    @override
+    def register_server_request_hooks(
+        self, registry: ServerRequestHookRegistry
+    ) -> None:
+        super().register_server_request_hooks(registry)
+        registry.register(
+            DENO_TEST_MODULE_DELETE,
+            ServerNotificationHook(
+                cls=TestModuleDeleteNotification,
+                execute=self.receive_deno_test_module_delete,
+            ),
+        )
+
+
+@runtime_checkable
+class WithReceiveDenoTestRunProgress(
+    ServerRequestHookProtocol,
+    CapabilityClientProtocol,
+    Protocol,
+):
+    @override
+    @classmethod
+    def methods(cls) -> Sequence[str]:
+        return (DENO_TEST_RUN_PROGRESS,)
+
+    async def receive_deno_test_run_progress(
+        self, noti: TestRunProgressNotification
+    ) -> None:
+        logger.debug("Received Deno test run progress: {}", noti.params)
+
+    @override
+    def register_server_request_hooks(
+        self, registry: ServerRequestHookRegistry
+    ) -> None:
+        super().register_server_request_hooks(registry)
+        registry.register(
+            DENO_TEST_RUN_PROGRESS,
+            ServerNotificationHook(
+                cls=TestRunProgressNotification,
+                execute=self.receive_deno_test_run_progress,
+            ),
+        )

--- a/src/lsp_client/clients/deno/extension.py
+++ b/src/lsp_client/clients/deno/extension.py
@@ -28,29 +28,29 @@ from .models import (
     DENO_TEST_RUN_CANCEL,
     DENO_TEST_RUN_PROGRESS,
     DENO_VIRTUAL_TEXT_DOCUMENT,
-    CacheParams,
-    CacheRequest,
-    CacheResponse,
-    PerformanceRequest,
-    PerformanceResponse,
-    RegistryStatusNotification,
-    ReloadImportRegistriesRequest,
-    ReloadImportRegistriesResponse,
-    TaskRequest,
-    TaskResponse,
-    TestModuleDeleteNotification,
-    TestModuleNotification,
-    TestRunCancelParams,
-    TestRunCancelRequest,
-    TestRunCancelResponse,
-    TestRunProgressNotification,
-    TestRunRequest,
-    TestRunRequestParams,
-    TestRunResponse,
-    TestRunResponseParams,
-    VirtualTextDocumentParams,
-    VirtualTextDocumentRequest,
-    VirtualTextDocumentResponse,
+    DenoCacheParams,
+    DenoCacheRequest,
+    DenoCacheResponse,
+    DenoPerformanceRequest,
+    DenoPerformanceResponse,
+    DenoRegistryStatusNotification,
+    DenoReloadImportRegistriesRequest,
+    DenoReloadImportRegistriesResponse,
+    DenoTaskRequest,
+    DenoTaskResponse,
+    DenoTestModuleDeleteNotification,
+    DenoTestModuleNotification,
+    DenoTestRunCancelParams,
+    DenoTestRunCancelRequest,
+    DenoTestRunCancelResponse,
+    DenoTestRunProgressNotification,
+    DenoTestRunRequest,
+    DenoTestRunRequestParams,
+    DenoTestRunResponse,
+    DenoTestRunResponseParams,
+    DenoVirtualTextDocumentParams,
+    DenoVirtualTextDocumentRequest,
+    DenoVirtualTextDocumentResponse,
 )
 
 
@@ -71,9 +71,9 @@ class WithRequestDenoCache(
         uris: Sequence[AnyPath] = (),
     ) -> None:
         return await self.request(
-            CacheRequest(
+            DenoCacheRequest(
                 id=jsonrpc_uuid(),
-                params=CacheParams(
+                params=DenoCacheParams(
                     referrer=lsp_type.TextDocumentIdentifier(uri=self.as_uri(referrer)),
                     uris=[
                         lsp_type.TextDocumentIdentifier(uri=self.as_uri(uri))
@@ -81,7 +81,7 @@ class WithRequestDenoCache(
                     ],
                 ),
             ),
-            schema=CacheResponse,
+            schema=DenoCacheResponse,
         )
 
 
@@ -98,8 +98,8 @@ class WithRequestDenoPerformance(
 
     async def request_deno_performance(self) -> Any:
         return await self.request(
-            PerformanceRequest(id=jsonrpc_uuid()),
-            schema=PerformanceResponse,
+            DenoPerformanceRequest(id=jsonrpc_uuid()),
+            schema=DenoPerformanceResponse,
         )
 
 
@@ -116,8 +116,8 @@ class WithRequestDenoReloadImportRegistries(
 
     async def request_deno_reload_import_registries(self) -> None:
         return await self.request(
-            ReloadImportRegistriesRequest(id=jsonrpc_uuid()),
-            schema=ReloadImportRegistriesResponse,
+            DenoReloadImportRegistriesRequest(id=jsonrpc_uuid()),
+            schema=DenoReloadImportRegistriesResponse,
         )
 
 
@@ -137,13 +137,13 @@ class WithRequestDenoVirtualTextDocument(
         uri: str,
     ) -> str:
         return await self.request(
-            VirtualTextDocumentRequest(
+            DenoVirtualTextDocumentRequest(
                 id=jsonrpc_uuid(),
-                params=VirtualTextDocumentParams(
+                params=DenoVirtualTextDocumentParams(
                     text_document=lsp_type.TextDocumentIdentifier(uri=uri)
                 ),
             ),
-            schema=VirtualTextDocumentResponse,
+            schema=DenoVirtualTextDocumentResponse,
         )
 
 
@@ -160,16 +160,16 @@ class WithRequestDenoTask(
 
     async def request_deno_task(self) -> list[Any]:
         return await self.request(
-            TaskRequest(id=jsonrpc_uuid()),
-            schema=TaskResponse,
+            DenoTaskRequest(id=jsonrpc_uuid()),
+            schema=DenoTaskResponse,
         )
 
 
 @runtime_checkable
 class WithRequestDenoTestRun(
+    ExperimentalCapabilityProtocol,
     CapabilityProtocol,
     CapabilityClientProtocol,
-    ExperimentalCapabilityProtocol,
     Protocol,
 ):
     @override
@@ -184,14 +184,14 @@ class WithRequestDenoTestRun(
 
     async def request_deno_test_run(
         self,
-        params: TestRunRequestParams,
-    ) -> TestRunResponseParams:
+        params: DenoTestRunRequestParams,
+    ) -> DenoTestRunResponseParams:
         return await self.request(
-            TestRunRequest(
+            DenoTestRunRequest(
                 id=jsonrpc_uuid(),
                 params=params,
             ),
-            schema=TestRunResponse,
+            schema=DenoTestRunResponse,
         )
 
 
@@ -211,11 +211,11 @@ class WithRequestDenoTestRunCancel(
         test_run_id: int,
     ) -> None:
         return await self.request(
-            TestRunCancelRequest(
+            DenoTestRunCancelRequest(
                 id=jsonrpc_uuid(),
-                params=TestRunCancelParams(id=test_run_id),
+                params=DenoTestRunCancelParams(id=test_run_id),
             ),
-            schema=TestRunCancelResponse,
+            schema=DenoTestRunCancelResponse,
         )
 
 
@@ -231,7 +231,7 @@ class WithReceiveDenoRegistryStatus(
         return (DENO_REGISTRY_STATE,)
 
     async def receive_deno_registry_state(
-        self, noti: RegistryStatusNotification
+        self, noti: DenoRegistryStatusNotification
     ) -> None:
         logger.debug("Received Deno registry state: {}", noti.params)
 
@@ -243,7 +243,7 @@ class WithReceiveDenoRegistryStatus(
         registry.register(
             DENO_REGISTRY_STATE,
             ServerNotificationHook(
-                cls=RegistryStatusNotification,
+                cls=DenoRegistryStatusNotification,
                 execute=self.receive_deno_registry_state,
             ),
         )
@@ -260,7 +260,7 @@ class WithReceiveDenoTestModule(
     def methods(cls) -> Sequence[str]:
         return (DENO_TEST_MODULE,)
 
-    async def receive_deno_test_module(self, noti: TestModuleNotification) -> None:
+    async def receive_deno_test_module(self, noti: DenoTestModuleNotification) -> None:
         logger.debug("Received Deno test module: {}", noti.params)
 
     @override
@@ -271,7 +271,7 @@ class WithReceiveDenoTestModule(
         registry.register(
             DENO_TEST_MODULE,
             ServerNotificationHook(
-                cls=TestModuleNotification,
+                cls=DenoTestModuleNotification,
                 execute=self.receive_deno_test_module,
             ),
         )
@@ -289,7 +289,7 @@ class WithReceiveDenoTestModuleDelete(
         return (DENO_TEST_MODULE_DELETE,)
 
     async def receive_deno_test_module_delete(
-        self, noti: TestModuleDeleteNotification
+        self, noti: DenoTestModuleDeleteNotification
     ) -> None:
         logger.debug("Received Deno test module delete: {}", noti.params)
 
@@ -301,7 +301,7 @@ class WithReceiveDenoTestModuleDelete(
         registry.register(
             DENO_TEST_MODULE_DELETE,
             ServerNotificationHook(
-                cls=TestModuleDeleteNotification,
+                cls=DenoTestModuleDeleteNotification,
                 execute=self.receive_deno_test_module_delete,
             ),
         )
@@ -319,7 +319,7 @@ class WithReceiveDenoTestRunProgress(
         return (DENO_TEST_RUN_PROGRESS,)
 
     async def receive_deno_test_run_progress(
-        self, noti: TestRunProgressNotification
+        self, noti: DenoTestRunProgressNotification
     ) -> None:
         logger.debug("Received Deno test run progress: {}", noti.params)
 
@@ -331,7 +331,7 @@ class WithReceiveDenoTestRunProgress(
         registry.register(
             DENO_TEST_RUN_PROGRESS,
             ServerNotificationHook(
-                cls=TestRunProgressNotification,
+                cls=DenoTestRunProgressNotification,
                 execute=self.receive_deno_test_run_progress,
             ),
         )

--- a/src/lsp_client/clients/deno/extension.py
+++ b/src/lsp_client/clients/deno/extension.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Protocol, override
+
+from lsp_client.protocol import (
+    CapabilityClientProtocol,
+    CapabilityProtocol,
+    ServerRequestHookProtocol,
+)
+
+
+class WithDenoCacheRequest(
+    ServerRequestHookProtocol,
+    CapabilityProtocol,
+    CapabilityClientProtocol,
+    Protocol,
+):
+    @override
+    @classmethod
+    def methods(cls) -> Sequence[str]:
+        return ("deno/cache",)

--- a/src/lsp_client/clients/deno/models.py
+++ b/src/lsp_client/clients/deno/models.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from typing import Any, Literal
 
 from attrs import define, field
-from lsprotocol import types as lsp_type
 
 from lsp_client.jsonrpc.id import ID
+from lsp_client.utils.types import lsp_type
 
 # ---------------------------------- Constants --------------------------------- #
 
@@ -116,6 +116,34 @@ class CacheRequest:
 
 @define
 class CacheResponse:
+    id: ID | None
+    result: None
+    jsonrpc: str = "2.0"
+
+
+@define
+class PerformanceRequest:
+    id: ID
+    method: Literal["deno/performance"] = DENO_PERFORMANCE
+    jsonrpc: str = "2.0"
+
+
+@define
+class PerformanceResponse:
+    id: ID | None
+    result: Any
+    jsonrpc: str = "2.0"
+
+
+@define
+class ReloadImportRegistriesRequest:
+    id: ID
+    method: Literal["deno/reloadImportRegistries"] = DENO_RELOAD_IMPORT_REGISTRIES
+    jsonrpc: str = "2.0"
+
+
+@define
+class ReloadImportRegistriesResponse:
     id: ID | None
     result: None
     jsonrpc: str = "2.0"

--- a/src/lsp_client/clients/deno/models.py
+++ b/src/lsp_client/clients/deno/models.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
-from attrs import define, field
+import cattrs
+from attrs import define, field, resolve_types
+from lsprotocol import converters
 
 from lsp_client.jsonrpc.id import ID
 from lsp_client.utils.types import lsp_type
@@ -30,22 +32,22 @@ DENO_TEST_RUN_PROGRESS: Literal["deno/testRunProgress"] = "deno/testRunProgress"
 
 
 @define
-class TestData:
+class DenoTestData:
     id: str
     label: str
-    steps: list[TestData] | None = None
+    steps: list[DenoTestData] | None = None
     range: lsp_type.Range | None = None
 
 
 @define
-class TestIdentifier:
+class DenoTestIdentifier:
     text_document: lsp_type.TextDocumentIdentifier
     id: str | None = None
     step_id: str | None = None
 
 
 @define
-class TestMessage:
+class DenoTestMessage:
     message: lsp_type.MarkupContent
     expected_output: str | None = None
     actual_output: str | None = None
@@ -53,46 +55,50 @@ class TestMessage:
 
 
 @define
-class TestEnqueuedStartedSkipped:
+class DenoTestEnqueuedStartedSkipped:
     type: Literal["enqueued", "started", "skipped"]
-    test: TestIdentifier
+    test: DenoTestIdentifier
 
 
 @define
-class TestFailedErrored:
+class DenoTestFailedErrored:
     type: Literal["failed", "errored"]
-    test: TestIdentifier
-    messages: list[TestMessage]
+    test: DenoTestIdentifier
+    messages: list[DenoTestMessage]
     duration: float | None = None
 
 
 @define
-class TestPassed:
+class DenoTestPassed:
     type: Literal["passed"]
-    test: TestIdentifier
+    test: DenoTestIdentifier
     duration: float | None = None
 
 
 @define
-class TestOutput:
+class DenoTestOutput:
     type: Literal["output"]
     value: str
-    test: TestIdentifier | None = None
+    test: DenoTestIdentifier | None = None
     location: lsp_type.Location | None = None
 
 
 @define
-class TestEnd:
+class DenoTestEnd:
     type: Literal["end"]
 
 
-type TestRunProgressMessage = (
-    TestEnqueuedStartedSkipped | TestFailedErrored | TestPassed | TestOutput | TestEnd
+type DenoTestRunProgressMessage = (
+    DenoTestEnqueuedStartedSkipped
+    | DenoTestFailedErrored
+    | DenoTestPassed
+    | DenoTestOutput
+    | DenoTestEnd
 )
 
 
 @define
-class EnqueuedTestModule:
+class DenoEnqueuedTestModule:
     text_document: lsp_type.TextDocumentIdentifier
     ids: list[str]
 
@@ -101,137 +107,137 @@ class EnqueuedTestModule:
 
 
 @define
-class CacheParams:
+class DenoCacheParams:
     referrer: lsp_type.TextDocumentIdentifier
     uris: list[lsp_type.TextDocumentIdentifier] = field(factory=list)
 
 
 @define
-class CacheRequest:
+class DenoCacheRequest:
     id: ID
-    params: CacheParams
+    params: DenoCacheParams
     method: Literal["deno/cache"] = DENO_CACHE
     jsonrpc: str = "2.0"
 
 
 @define
-class CacheResponse:
+class DenoCacheResponse:
     id: ID | None
     result: None
     jsonrpc: str = "2.0"
 
 
 @define
-class PerformanceRequest:
+class DenoPerformanceRequest:
     id: ID
     method: Literal["deno/performance"] = DENO_PERFORMANCE
     jsonrpc: str = "2.0"
 
 
 @define
-class PerformanceResponse:
+class DenoPerformanceResponse:
     id: ID | None
     result: Any
     jsonrpc: str = "2.0"
 
 
 @define
-class ReloadImportRegistriesRequest:
+class DenoReloadImportRegistriesRequest:
     id: ID
     method: Literal["deno/reloadImportRegistries"] = DENO_RELOAD_IMPORT_REGISTRIES
     jsonrpc: str = "2.0"
 
 
 @define
-class ReloadImportRegistriesResponse:
+class DenoReloadImportRegistriesResponse:
     id: ID | None
     result: None
     jsonrpc: str = "2.0"
 
 
 @define
-class VirtualTextDocumentParams:
+class DenoVirtualTextDocumentParams:
     text_document: lsp_type.TextDocumentIdentifier
 
 
 @define
-class VirtualTextDocumentRequest:
+class DenoVirtualTextDocumentRequest:
     id: ID
-    params: VirtualTextDocumentParams
+    params: DenoVirtualTextDocumentParams
     method: Literal["deno/virtualTextDocument"] = DENO_VIRTUAL_TEXT_DOCUMENT
     jsonrpc: str = "2.0"
 
 
 @define
-class VirtualTextDocumentResponse:
+class DenoVirtualTextDocumentResponse:
     id: ID | None
     result: str
     jsonrpc: str = "2.0"
 
 
 @define
-class TaskParams:
+class DenoTaskParams:
     pass
 
 
 @define
-class TaskRequest:
+class DenoTaskRequest:
     id: ID
-    params: TaskParams | None = None
+    params: DenoTaskParams | None = None
     method: Literal["deno/task"] = DENO_TASK
     jsonrpc: str = "2.0"
 
 
 @define
-class TaskResponse:
+class DenoTaskResponse:
     id: ID | None
     result: list[Any]
     jsonrpc: str = "2.0"
 
 
 @define
-class TestRunRequestParams:
+class DenoTestRunRequestParams:
     id: int
     kind: Literal["run", "coverage", "debug"]
-    exclude: list[TestIdentifier] | None = None
-    include: list[TestIdentifier] | None = None
+    exclude: list[DenoTestIdentifier] | None = None
+    include: list[DenoTestIdentifier] | None = None
 
 
 @define
-class TestRunRequest:
+class DenoTestRunRequest:
     id: ID
-    params: TestRunRequestParams
+    params: DenoTestRunRequestParams
     method: Literal["deno/testRun"] = DENO_TEST_RUN
     jsonrpc: str = "2.0"
 
 
 @define
-class TestRunResponseParams:
-    enqueued: list[EnqueuedTestModule]
+class DenoTestRunResponseParams:
+    enqueued: list[DenoEnqueuedTestModule]
 
 
 @define
-class TestRunResponse:
+class DenoTestRunResponse:
     id: ID | None
-    result: TestRunResponseParams
+    result: DenoTestRunResponseParams
     jsonrpc: str = "2.0"
 
 
 @define
-class TestRunCancelParams:
+class DenoTestRunCancelParams:
     id: int
 
 
 @define
-class TestRunCancelRequest:
+class DenoTestRunCancelRequest:
     id: ID
-    params: TestRunCancelParams
+    params: DenoTestRunCancelParams
     method: Literal["deno/testRunCancel"] = DENO_TEST_RUN_CANCEL
     jsonrpc: str = "2.0"
 
 
 @define
-class TestRunCancelResponse:
+class DenoTestRunCancelResponse:
     id: ID | None
     result: None
     jsonrpc: str = "2.0"
@@ -241,53 +247,122 @@ class TestRunCancelResponse:
 
 
 @define
-class RegistryStatusNotificationParams:
+class DenoRegistryStatusNotificationParams:
     origin: str
     suggestions: bool
 
 
 @define
-class RegistryStatusNotification:
-    params: RegistryStatusNotificationParams
+class DenoRegistryStatusNotification:
+    params: DenoRegistryStatusNotificationParams
     method: Literal["deno/registryState"] = DENO_REGISTRY_STATE
     jsonrpc: str = "2.0"
 
 
 @define
-class TestModuleParams:
+class DenoTestModuleParams:
     text_document: lsp_type.TextDocumentIdentifier
     kind: Literal["insert", "replace"]
     label: str
-    tests: list[TestData]
+    tests: list[DenoTestData]
 
 
 @define
-class TestModuleNotification:
-    params: TestModuleParams
+class DenoTestModuleNotification:
+    params: DenoTestModuleParams
     method: Literal["deno/testModule"] = DENO_TEST_MODULE
     jsonrpc: str = "2.0"
 
 
 @define
-class TestModuleDeleteParams:
+class DenoTestModuleDeleteParams:
     text_document: lsp_type.TextDocumentIdentifier
 
 
 @define
-class TestModuleDeleteNotification:
-    params: TestModuleDeleteParams
+class DenoTestModuleDeleteNotification:
+    params: DenoTestModuleDeleteParams
     method: Literal["deno/testModuleDelete"] = DENO_TEST_MODULE_DELETE
     jsonrpc: str = "2.0"
 
 
 @define
-class TestRunProgressParams:
+class DenoTestRunProgressParams:
     id: int
-    message: TestRunProgressMessage
+    message: DenoTestRunProgressMessage
 
 
 @define
-class TestRunProgressNotification:
-    params: TestRunProgressParams
+class DenoTestRunProgressNotification:
+    params: DenoTestRunProgressParams
     method: Literal["deno/testRunProgress"] = DENO_TEST_RUN_PROGRESS
     jsonrpc: str = "2.0"
+
+
+def register_hooks(converter: cattrs.Converter) -> None:
+    resolve_types(DenoTestData)
+    resolve_types(DenoTestIdentifier)
+    resolve_types(DenoTestMessage)
+    resolve_types(DenoTestEnqueuedStartedSkipped)
+    resolve_types(DenoTestFailedErrored)
+    resolve_types(DenoTestPassed)
+    resolve_types(DenoTestOutput)
+    resolve_types(DenoTestEnd)
+    resolve_types(DenoEnqueuedTestModule)
+    resolve_types(DenoCacheParams)
+    resolve_types(DenoCacheRequest)
+    resolve_types(DenoCacheResponse)
+    resolve_types(DenoPerformanceRequest)
+    resolve_types(DenoPerformanceResponse)
+    resolve_types(DenoReloadImportRegistriesRequest)
+    resolve_types(DenoReloadImportRegistriesResponse)
+    resolve_types(DenoVirtualTextDocumentParams)
+    resolve_types(DenoVirtualTextDocumentRequest)
+    resolve_types(DenoVirtualTextDocumentResponse)
+    resolve_types(DenoTaskParams)
+    resolve_types(DenoTaskRequest)
+    resolve_types(DenoTaskResponse)
+    resolve_types(DenoTestRunRequestParams)
+    resolve_types(DenoTestRunRequest)
+    resolve_types(DenoTestRunResponseParams)
+    resolve_types(DenoTestRunResponse)
+    resolve_types(DenoTestRunCancelParams)
+    resolve_types(DenoTestRunCancelRequest)
+    resolve_types(DenoTestRunCancelResponse)
+    resolve_types(DenoRegistryStatusNotificationParams)
+    resolve_types(DenoRegistryStatusNotification)
+    resolve_types(DenoTestModuleParams)
+    resolve_types(DenoTestModuleNotification)
+    resolve_types(DenoTestModuleDeleteParams)
+    resolve_types(DenoTestModuleDeleteNotification)
+    resolve_types(DenoTestRunProgressParams)
+    resolve_types(DenoTestRunProgressNotification)
+
+    def _test_run_progress_message_hook(
+        obj: Any, _: type
+    ) -> DenoTestRunProgressMessage:
+        if not isinstance(obj, dict):
+            return obj
+
+        match obj.get("type"):
+            case "enqueued" | "started" | "skipped":
+                return converter.structure(obj, DenoTestEnqueuedStartedSkipped)
+            case "failed" | "errored":
+                return converter.structure(obj, DenoTestFailedErrored)
+            case "passed":
+                return converter.structure(obj, DenoTestPassed)
+            case "output":
+                return converter.structure(obj, DenoTestOutput)
+            case "end":
+                return converter.structure(obj, DenoTestEnd)
+            case _:
+                raise ValueError(
+                    f"Unknown DenoTestRunProgressMessage type: {obj.get('type')}"
+                )
+
+    converter.register_structure_hook(
+        DenoTestRunProgressMessage, _test_run_progress_message_hook
+    )
+
+
+register_hooks(converters.get_converter())

--- a/src/lsp_client/clients/deno/models.py
+++ b/src/lsp_client/clients/deno/models.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from attrs import define, field
+from lsprotocol import types as lsp_type
+
+from lsp_client.jsonrpc.id import ID
+
+# ---------------------------------- Constants --------------------------------- #
+
+DENO_CACHE: Literal["deno/cache"] = "deno/cache"
+DENO_PERFORMANCE: Literal["deno/performance"] = "deno/performance"
+DENO_RELOAD_IMPORT_REGISTRIES: Literal["deno/reloadImportRegistries"] = (
+    "deno/reloadImportRegistries"
+)
+DENO_VIRTUAL_TEXT_DOCUMENT: Literal["deno/virtualTextDocument"] = (
+    "deno/virtualTextDocument"
+)
+DENO_TASK: Literal["deno/task"] = "deno/task"
+DENO_REGISTRY_STATE: Literal["deno/registryState"] = "deno/registryState"
+DENO_TEST_RUN: Literal["deno/testRun"] = "deno/testRun"
+DENO_TEST_RUN_CANCEL: Literal["deno/testRunCancel"] = "deno/testRunCancel"
+DENO_TEST_MODULE: Literal["deno/testModule"] = "deno/testModule"
+DENO_TEST_MODULE_DELETE: Literal["deno/testModuleDelete"] = "deno/testModuleDelete"
+DENO_TEST_RUN_PROGRESS: Literal["deno/testRunProgress"] = "deno/testRunProgress"
+
+
+# --------------------------------- Base Types -------------------------------- #
+
+
+@define
+class TestData:
+    id: str
+    label: str
+    steps: list[TestData] | None = None
+    range: lsp_type.Range | None = None
+
+
+@define
+class TestIdentifier:
+    text_document: lsp_type.TextDocumentIdentifier
+    id: str | None = None
+    step_id: str | None = None
+
+
+@define
+class TestMessage:
+    message: lsp_type.MarkupContent
+    expected_output: str | None = None
+    actual_output: str | None = None
+    location: lsp_type.Location | None = None
+
+
+@define
+class TestEnqueuedStartedSkipped:
+    type: Literal["enqueued", "started", "skipped"]
+    test: TestIdentifier
+
+
+@define
+class TestFailedErrored:
+    type: Literal["failed", "errored"]
+    test: TestIdentifier
+    messages: list[TestMessage]
+    duration: float | None = None
+
+
+@define
+class TestPassed:
+    type: Literal["passed"]
+    test: TestIdentifier
+    duration: float | None = None
+
+
+@define
+class TestOutput:
+    type: Literal["output"]
+    value: str
+    test: TestIdentifier | None = None
+    location: lsp_type.Location | None = None
+
+
+@define
+class TestEnd:
+    type: Literal["end"]
+
+
+type TestRunProgressMessage = (
+    TestEnqueuedStartedSkipped | TestFailedErrored | TestPassed | TestOutput | TestEnd
+)
+
+
+@define
+class EnqueuedTestModule:
+    text_document: lsp_type.TextDocumentIdentifier
+    ids: list[str]
+
+
+# ---------------------------------- Requests --------------------------------- #
+
+
+@define
+class CacheParams:
+    referrer: lsp_type.TextDocumentIdentifier
+    uris: list[lsp_type.TextDocumentIdentifier] = field(factory=list)
+
+
+@define
+class CacheRequest:
+    id: ID
+    params: CacheParams
+    method: Literal["deno/cache"] = DENO_CACHE
+    jsonrpc: str = "2.0"
+
+
+@define
+class CacheResponse:
+    id: ID | None
+    result: None
+    jsonrpc: str = "2.0"
+
+
+@define
+class VirtualTextDocumentParams:
+    text_document: lsp_type.TextDocumentIdentifier
+
+
+@define
+class VirtualTextDocumentRequest:
+    id: ID
+    params: VirtualTextDocumentParams
+    method: Literal["deno/virtualTextDocument"] = DENO_VIRTUAL_TEXT_DOCUMENT
+    jsonrpc: str = "2.0"
+
+
+@define
+class VirtualTextDocumentResponse:
+    id: ID | None
+    result: str
+    jsonrpc: str = "2.0"
+
+
+@define
+class TaskParams:
+    pass
+
+
+@define
+class TaskRequest:
+    id: ID
+    params: TaskParams | None = None
+    method: Literal["deno/task"] = DENO_TASK
+    jsonrpc: str = "2.0"
+
+
+@define
+class TaskResponse:
+    id: ID | None
+    result: list[Any]
+    jsonrpc: str = "2.0"
+
+
+@define
+class TestRunRequestParams:
+    id: int
+    kind: Literal["run", "coverage", "debug"]
+    exclude: list[TestIdentifier] | None = None
+    include: list[TestIdentifier] | None = None
+
+
+@define
+class TestRunRequest:
+    id: ID
+    params: TestRunRequestParams
+    method: Literal["deno/testRun"] = DENO_TEST_RUN
+    jsonrpc: str = "2.0"
+
+
+@define
+class TestRunResponseParams:
+    enqueued: list[EnqueuedTestModule]
+
+
+@define
+class TestRunResponse:
+    id: ID | None
+    result: TestRunResponseParams
+    jsonrpc: str = "2.0"
+
+
+@define
+class TestRunCancelParams:
+    id: int
+
+
+@define
+class TestRunCancelRequest:
+    id: ID
+    params: TestRunCancelParams
+    method: Literal["deno/testRunCancel"] = DENO_TEST_RUN_CANCEL
+    jsonrpc: str = "2.0"
+
+
+@define
+class TestRunCancelResponse:
+    id: ID | None
+    result: None
+    jsonrpc: str = "2.0"
+
+
+# -------------------------------- Notifications ------------------------------- #
+
+
+@define
+class RegistryStatusNotificationParams:
+    origin: str
+    suggestions: bool
+
+
+@define
+class RegistryStatusNotification:
+    params: RegistryStatusNotificationParams
+    method: Literal["deno/registryState"] = DENO_REGISTRY_STATE
+    jsonrpc: str = "2.0"
+
+
+@define
+class TestModuleParams:
+    text_document: lsp_type.TextDocumentIdentifier
+    kind: Literal["insert", "replace"]
+    label: str
+    tests: list[TestData]
+
+
+@define
+class TestModuleNotification:
+    params: TestModuleParams
+    method: Literal["deno/testModule"] = DENO_TEST_MODULE
+    jsonrpc: str = "2.0"
+
+
+@define
+class TestModuleDeleteParams:
+    text_document: lsp_type.TextDocumentIdentifier
+
+
+@define
+class TestModuleDeleteNotification:
+    params: TestModuleDeleteParams
+    method: Literal["deno/testModuleDelete"] = DENO_TEST_MODULE_DELETE
+    jsonrpc: str = "2.0"
+
+
+@define
+class TestRunProgressParams:
+    id: int
+    message: TestRunProgressMessage
+
+
+@define
+class TestRunProgressNotification:
+    params: TestRunProgressParams
+    method: Literal["deno/testRunProgress"] = DENO_TEST_RUN_PROGRESS
+    jsonrpc: str = "2.0"

--- a/src/lsp_client/protocol/__init__.py
+++ b/src/lsp_client/protocol/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from .capability import (
     CapabilityProtocol,
+    ExperimentalCapabilityProtocol,
     GeneralCapabilityProtocol,
     NotebookCapabilityProtocol,
     TextDocumentCapabilityProtocol,
@@ -21,6 +22,7 @@ from .hook import (
 __all__ = [
     "CapabilityClientProtocol",
     "CapabilityProtocol",
+    "ExperimentalCapabilityProtocol",
     "GeneralCapabilityProtocol",
     "NotebookCapabilityProtocol",
     "ServerNotificationHook",

--- a/src/lsp_client/protocol/capability.py
+++ b/src/lsp_client/protocol/capability.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from collections.abc import Sequence
-from typing import Protocol, runtime_checkable
+from typing import Any, Protocol, runtime_checkable
 
 from lsp_client.utils.types import lsp_type
 
@@ -112,4 +112,18 @@ class GeneralCapabilityProtocol(
     def register_general_capability(
         cls, cap: lsp_type.GeneralClientCapabilities
     ) -> None:
+        return
+
+
+@runtime_checkable
+class ExperimentalCapabilityProtocol(
+    CapabilityProtocol,
+    Protocol,
+):
+    """
+    LSP `experimental` capability.
+    """
+
+    @classmethod
+    def register_experimental_capability(cls, cap: dict[str, Any]) -> None:
         return


### PR DESCRIPTION
## Summary
- Added Deno LSP client implementation in `src/lsp_client/clients/deno/`.
- Includes client class, models, and extension for Deno-specific functionality.