### PR TITLE
feat: add support for textDocument/completion capability

### DIFF
--- a/src/lsp_client/capability/request/__init__.py
+++ b/src/lsp_client/capability/request/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Final
 
 from .call_hierarchy import WithRequestCallHierarchy
+from .completion import WithRequestCompletion
 from .declaration import WithRequestDeclaration
 from .definition import WithRequestDefinition
 from .document_symbol import WithRequestDocumentSymbol
@@ -16,6 +17,7 @@ from .workspace_symbol import WithRequestWorkspaceSymbol
 
 capabilities: Final = (
     WithRequestCallHierarchy,
+    WithRequestCompletion,
     WithRequestDeclaration,
     WithRequestDefinition,
     WithRequestDocumentSymbol,
@@ -30,6 +32,7 @@ capabilities: Final = (
 
 __all__ = [
     "WithRequestCallHierarchy",
+    "WithRequestCompletion",
     "WithRequestDeclaration",
     "WithRequestDefinition",
     "WithRequestDocumentSymbol",

--- a/src/lsp_client/capability/request/completion.py
+++ b/src/lsp_client/capability/request/completion.py
@@ -21,7 +21,8 @@ class WithRequestCompletion(
     Protocol,
 ):
     """
-    `textDocument/completion` - https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_completion
+    - `textDocument/completion` - https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_completion
+    - `completionItem/resolve` - https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#completionItem_resolve
     """
 
     @override

--- a/src/lsp_client/capability/request/completion.py
+++ b/src/lsp_client/capability/request/completion.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Protocol, override, runtime_checkable
+
+import asyncer
+
+from lsp_client.jsonrpc.id import jsonrpc_uuid
+from lsp_client.protocol import (
+    CapabilityClientProtocol,
+    TextDocumentCapabilityProtocol,
+)
+from lsp_client.utils.type_guard import is_completion_items
+from lsp_client.utils.types import AnyPath, Position, lsp_type
+
+
+@runtime_checkable
+class WithRequestCompletion(
+    TextDocumentCapabilityProtocol,
+    CapabilityClientProtocol,
+    Protocol,
+):
+    """
+    `textDocument/completion` - https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_completion
+    """
+
+    @override
+    @classmethod
+    def methods(cls) -> Sequence[str]:
+        return (
+            lsp_type.TEXT_DOCUMENT_COMPLETION,
+            lsp_type.COMPLETION_ITEM_RESOLVE,
+        )
+
+    @override
+    @classmethod
+    def register_text_document_capability(
+        cls, cap: lsp_type.TextDocumentClientCapabilities
+    ) -> None:
+        cap.completion = lsp_type.CompletionClientCapabilities(
+            completion_item=lsp_type.ClientCompletionItemOptions(
+                snippet_support=True,
+                resolve_support=lsp_type.ClientCompletionItemResolveOptions(
+                    properties=["documentation", "additionalTextEdits"]
+                ),
+            ),
+            context_support=True,
+        )
+
+    @override
+    @classmethod
+    def check_server_capability(
+        cls,
+        cap: lsp_type.ServerCapabilities,
+        info: lsp_type.ServerInfo | None,
+    ) -> None:
+        super().check_server_capability(cap, info)
+        assert cap.completion_provider
+
+    async def request_completion(
+        self,
+        file_path: AnyPath,
+        position: Position,
+        *,
+        trigger_character: str | None = None,
+        trigger_kind: lsp_type.CompletionTriggerKind = lsp_type.CompletionTriggerKind.Invoked,
+        resolve: bool = False,
+    ) -> Sequence[lsp_type.CompletionItem]:
+        context = lsp_type.CompletionContext(
+            trigger_kind=trigger_kind,
+            trigger_character=trigger_character,
+        )
+        result = await self.file_request(
+            lsp_type.CompletionRequest(
+                id=jsonrpc_uuid(),
+                params=lsp_type.CompletionParams(
+                    text_document=lsp_type.TextDocumentIdentifier(
+                        uri=self.as_uri(file_path)
+                    ),
+                    position=position,
+                    context=context,
+                ),
+            ),
+            schema=lsp_type.CompletionResponse,
+            file_paths=[file_path],
+        )
+
+        match result:
+            case lsp_type.CompletionList(items=items):
+                res = list(items)
+            case items if is_completion_items(items):
+                res = list(items)
+            case _:
+                res = []
+
+        if resolve and res:
+            return await self.resolve_completion_items(res)
+        return res
+
+    async def resolve_completion_items(
+        self,
+        items: Sequence[lsp_type.CompletionItem],
+    ) -> Sequence[lsp_type.CompletionItem]:
+        async with asyncer.create_task_group() as tg:
+            tasks = [
+                tg.soonify(self.request_completion_resolve)(item) for item in items
+            ]
+        return [task.value for task in tasks]
+
+    async def request_completion_resolve(
+        self,
+        item: lsp_type.CompletionItem,
+    ) -> lsp_type.CompletionItem:
+        return await self.request(
+            lsp_type.CompletionResolveRequest(
+                id=jsonrpc_uuid(),
+                params=item,
+            ),
+            schema=lsp_type.CompletionResolveResponse,
+        )

--- a/src/lsp_client/clients/deno/client.py
+++ b/src/lsp_client/clients/deno/client.py
@@ -11,6 +11,7 @@ from loguru import logger
 
 from lsp_client.capability.request import (
     WithRequestCallHierarchy,
+    WithRequestCompletion,
     WithRequestDefinition,
     WithRequestDocumentSymbol,
     WithRequestHover,
@@ -81,6 +82,7 @@ DenoLocalServer = partial(
 class DenoClient(
     Client,
     WithRequestHover,
+    WithRequestCompletion,
     WithRequestDefinition,
     WithRequestReferences,
     WithRequestImplementation,

--- a/src/lsp_client/clients/pyrefly.py
+++ b/src/lsp_client/clients/pyrefly.py
@@ -14,6 +14,7 @@ from lsp_client.capability.notification import (
 )
 from lsp_client.capability.request import (
     WithRequestCallHierarchy,
+    WithRequestCompletion,
     WithRequestDeclaration,
     WithRequestDefinition,
     WithRequestDocumentSymbol,
@@ -79,6 +80,7 @@ class PyreflyClient(
     Client,
     WithNotifyDidChangeConfiguration,
     WithRequestCallHierarchy,
+    WithRequestCompletion,
     WithRequestDeclaration,
     WithRequestDefinition,
     WithRequestDocumentSymbol,

--- a/src/lsp_client/clients/pyright.py
+++ b/src/lsp_client/clients/pyright.py
@@ -14,6 +14,7 @@ from lsp_client.capability.notification import (
 )
 from lsp_client.capability.request import (
     WithRequestCallHierarchy,
+    WithRequestCompletion,
     WithRequestDeclaration,
     WithRequestDefinition,
     WithRequestDocumentSymbol,
@@ -75,6 +76,7 @@ class PyrightClient(
     Client,
     WithNotifyDidChangeConfiguration,
     WithRequestCallHierarchy,
+    WithRequestCompletion,
     WithRequestDeclaration,
     WithRequestDefinition,
     WithRequestDocumentSymbol,

--- a/src/lsp_client/clients/rust_analyzer.py
+++ b/src/lsp_client/clients/rust_analyzer.py
@@ -14,6 +14,7 @@ from lsp_client.capability.notification import (
 )
 from lsp_client.capability.request import (
     WithRequestCallHierarchy,
+    WithRequestCompletion,
     WithRequestDeclaration,
     WithRequestDefinition,
     WithRequestDocumentSymbol,
@@ -75,6 +76,7 @@ class RustAnalyzerClient(
     Client,
     WithNotifyDidChangeConfiguration,
     WithRequestCallHierarchy,
+    WithRequestCompletion,
     WithRequestDeclaration,
     WithRequestDefinition,
     WithRequestDocumentSymbol,

--- a/src/lsp_client/clients/ty.py
+++ b/src/lsp_client/clients/ty.py
@@ -14,6 +14,7 @@ from lsp_client.capability.notification import (
     WithNotifyDidChangeConfiguration,
 )
 from lsp_client.capability.request import (
+    WithRequestCompletion,
     WithRequestDeclaration,
     WithRequestDefinition,
     WithRequestDocumentSymbol,
@@ -72,6 +73,7 @@ TyLocalServer = partial(
 class TyClient(
     Client,
     WithNotifyDidChangeConfiguration,
+    WithRequestCompletion,
     WithRequestDeclaration,
     WithRequestDefinition,
     WithRequestDocumentSymbol,

--- a/src/lsp_client/clients/typescript.py
+++ b/src/lsp_client/clients/typescript.py
@@ -13,6 +13,7 @@ from lsp_client.capability.notification import (
     WithNotifyDidChangeConfiguration,
 )
 from lsp_client.capability.request import (
+    WithRequestCompletion,
     WithRequestDefinition,
     WithRequestDocumentSymbol,
     WithRequestHover,
@@ -79,6 +80,7 @@ TypescriptLocalServer = partial(
 class TypescriptClient(
     Client,
     WithNotifyDidChangeConfiguration,
+    WithRequestCompletion,
     WithRequestHover,
     WithRequestDefinition,
     WithRequestReferences,

--- a/src/lsp_client/utils/type_guard.py
+++ b/src/lsp_client/utils/type_guard.py
@@ -42,3 +42,9 @@ def is_symbol_information_seq(
     return result is not None and all(
         isinstance(item, lsp_type.SymbolInformation) for item in result
     )
+
+
+def is_completion_items(result: Any) -> TypeGuard[Iterable[lsp_type.CompletionItem]]:
+    return result is not None and all(
+        isinstance(item, lsp_type.CompletionItem) for item in result
+    )


### PR DESCRIPTION
## Summary
- Implemented `WithRequestCompletion` capability for `textDocument/completion` and `completionItem/resolve` requests.
- Enabled completion support in Deno, Pyrefly, Pyright, Rust Analyzer, Ty, and TypeScript clients.
- Added a type guard for completion items.