### PR TITLE
Refactor: provide higher Server abstraction

### DIFF
--- a/src/lsp_client/__init__.py
+++ b/src/lsp_client/__init__.py
@@ -36,7 +36,7 @@ from __future__ import annotations
 from loguru import logger
 
 from .client.abc import Client
-from .server.abc import Server
+from .server.abc import Server, StreamServer
 from .server.container import ContainerServer
 from .server.local import LocalServer
 from .utils.types import *  # noqa: F403
@@ -63,6 +63,7 @@ __all__ = [
     "ContainerServer",
     "LocalServer",
     "Server",
+    "StreamServer",
     "disable_logging",
     "enable_logging",
 ]

--- a/src/lsp_client/client/abc.py
+++ b/src/lsp_client/client/abc.py
@@ -28,7 +28,8 @@ from lsp_client.jsonrpc.convert import (
     response_serialize,
 )
 from lsp_client.protocol import CapabilityClientProtocol, CapabilityProtocol
-from lsp_client.server import DefaultServers, Server, ServerRuntimeError
+from lsp_client.server import DefaultServers, ServerRuntimeError
+from lsp_client.server.abc import Server
 from lsp_client.server.types import ServerRequest
 from lsp_client.utils.channel import Receiver, channel
 from lsp_client.utils.config import ConfigurationMap

--- a/src/lsp_client/server/__init__.py
+++ b/src/lsp_client/server/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from .abc import Server
+from .abc import Server, StreamServer
 from .container import ContainerServer
 from .default import DefaultServers
 from .error import ServerError, ServerInstallationError, ServerRuntimeError
@@ -18,4 +18,5 @@ __all__ = [
     "ServerRuntimeError",
     "ServerType",
     "SocketServer",
+    "StreamServer",
 ]

--- a/src/lsp_client/server/abc.py
+++ b/src/lsp_client/server/abc.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from functools import cached_property
-from typing import Self
+from typing import Self, override
 
 import anyio
 import asyncer
@@ -28,9 +28,37 @@ from lsp_client.utils.workspace import Workspace
 
 @define
 class Server(ABC):
-    """Base server implementation with JSON-RPC protocol handling."""
+    @abstractmethod
+    async def check_availability(self) -> None:
+        """Check if the server runtime is available."""
+
+    @abstractmethod
+    async def request(self, request: RawRequest) -> RawResponsePackage:
+        """Send a request to the server and receive response or error."""
+
+    @abstractmethod
+    async def notify(self, notification: RawNotification) -> None:
+        """Send a notification to the server."""
+
+    @abstractmethod
+    async def kill(self) -> None:
+        """Terminate the server runtime."""
+
+    @abstractmethod
+    @asynccontextmanager
+    def run(
+        self,
+        workspace: Workspace,
+        sender: Sender[ServerRequest],
+    ) -> AsyncGenerator[Self]: ...
+
+
+@define
+class StreamServer(Server):
+    """Server based on byte streams with JSON-RPC protocol handling."""
 
     _resp_table: ResponseTable = field(factory=ResponseTable, init=False)
+    """Dispatch response by response ID."""
 
     @property
     @abstractmethod
@@ -41,10 +69,6 @@ class Server(ABC):
     @abstractmethod
     def receive_stream(self) -> AnyByteReceiveStream:
         """Stream for receiving data from the server."""
-
-    @abstractmethod
-    async def check_availability(self) -> None:
-        """Check if the server runtime is available."""
 
     async def setup(self, workspace: Workspace) -> None:
         """Hook called before starting server resources.
@@ -128,14 +152,17 @@ class Server(ABC):
             while package := await self.receive():
                 tg.soonify(self._handle_package)(sender, package)
 
+    @override
     async def request(self, request: RawRequest) -> RawResponsePackage:
         rx = self._resp_table.reserve(request["id"])
         await self.send(request)
         return await rx.receive()
 
+    @override
     async def notify(self, notification: RawNotification) -> None:
         await self.send(notification)
 
+    @override
     @asynccontextmanager
     async def run(
         self, workspace: Workspace, sender: Sender[ServerRequest]

--- a/src/lsp_client/server/abc.py
+++ b/src/lsp_client/server/abc.py
@@ -28,6 +28,18 @@ from lsp_client.utils.workspace import Workspace
 
 @define
 class Server(ABC):
+    """Abstract base class for language server runtimes.
+
+    This class defines the high-level contract for communicating with a
+    language server: checking availability, sending requests and
+    notifications, managing the server lifecycle, and running it within a
+    workspace context.
+
+    Unlike :class:`StreamServer`, which provides a concrete implementation
+    based on byte streams and JSON-RPC protocol handling, implementations of
+    :class:`Server` are free to choose how the underlying server process or
+    transport is managed, as long as they honor this interface.
+    """
     @abstractmethod
     async def check_availability(self) -> None:
         """Check if the server runtime is available."""

--- a/src/lsp_client/server/container.py
+++ b/src/lsp_client/server/container.py
@@ -13,7 +13,7 @@ from loguru import logger
 
 from lsp_client.utils.workspace import Workspace
 
-from .abc import Server
+from .abc import StreamServer
 from .local import LocalServer
 
 
@@ -122,7 +122,7 @@ def _format_mount(mount: Mount) -> str:
 
 @final
 @define
-class ContainerServer(Server):
+class ContainerServer(StreamServer):
     """Runtime for container backend, e.g. `docker` or `podman`."""
 
     image: str

--- a/src/lsp_client/server/local.py
+++ b/src/lsp_client/server/local.py
@@ -14,7 +14,7 @@ from loguru import logger
 from lsp_client.env import disable_auto_installation
 from lsp_client.utils.workspace import Workspace
 
-from .abc import Server
+from .abc import StreamServer
 from .error import ServerRuntimeError
 
 
@@ -23,7 +23,7 @@ class EnsureInstalledProtocol(Protocol):
 
 
 @define
-class LocalServer(Server):
+class LocalServer(StreamServer):
     program: str
     args: Sequence[str] = Factory(list)
 

--- a/src/lsp_client/server/socket.py
+++ b/src/lsp_client/server/socket.py
@@ -15,7 +15,7 @@ from lsp_client.server.error import ServerRuntimeError
 from lsp_client.utils.types import AnyPath
 from lsp_client.utils.workspace import Workspace
 
-from .abc import Server
+from .abc import StreamServer
 
 type TCPSocket = tuple[IPAddressType, int]
 """(host, port)"""
@@ -25,7 +25,7 @@ type UnixSocket = AnyPath
 
 @final
 @define
-class SocketServer(Server):
+class SocketServer(StreamServer):
     """Runtime for socket backend, e.g. connecting to a remote LSP server via TCP or Unix socket."""
 
     connection: TCPSocket | UnixSocket

--- a/tests/framework/mocks.py
+++ b/tests/framework/mocks.py
@@ -8,13 +8,13 @@ from unittest.mock import AsyncMock, MagicMock
 from anyio.abc import AnyByteReceiveStream, AnyByteSendStream
 from attrs import define, field
 
-from lsp_client.server.abc import Server
+from lsp_client.server.abc import StreamServer
 from lsp_client.utils.channel import Sender
 from lsp_client.utils.workspace import Workspace
 
 
 @define
-class MockServer(Server):
+class MockServer(StreamServer):
     """A mock server for testing without actual LSP server."""
 
     _send_stream: MagicMock = field(factory=MagicMock)


### PR DESCRIPTION
## Summary
- Introduced a higher-level `Server` abstract base class to support non-stream-based server implementations.
- Renamed the previous stream-based `Server` to `StreamServer`.
- Updated `Client` and other components to depend on the `Server` abstraction instead of concrete stream-based implementations.
- Maintained backward compatibility for existing `LocalServer`, `ContainerServer`, and `SocketServer` by inheriting from `StreamServer`.