### PR TITLE
fix: ensure hierarchical capability registration across mixins

### DIFF
--- a/src/lsp_client/capability/notification/did_change_configuration.py
+++ b/src/lsp_client/capability/notification/did_change_configuration.py
@@ -28,6 +28,7 @@ class WithNotifyDidChangeConfiguration(
     def register_workspace_capability(
         cls, cap: lsp_type.WorkspaceClientCapabilities
     ) -> None:
+        super().register_workspace_capability(cap)
         cap.did_change_configuration = (
             lsp_type.DidChangeConfigurationClientCapabilities()
         )

--- a/src/lsp_client/capability/notification/text_document_synchronize.py
+++ b/src/lsp_client/capability/notification/text_document_synchronize.py
@@ -34,6 +34,7 @@ class WithNotifyTextDocumentSynchronize(
     def register_text_document_capability(
         cls, cap: lsp_type.TextDocumentClientCapabilities
     ) -> None:
+        super().register_text_document_capability(cap)
         cap.synchronization = lsp_type.TextDocumentSyncClientCapabilities(
             will_save=True,
             will_save_wait_until=True,

--- a/src/lsp_client/capability/request/code_action.py
+++ b/src/lsp_client/capability/request/code_action.py
@@ -33,6 +33,7 @@ class WithRequestCodeAction(
     def register_text_document_capability(
         cls, cap: lsp_type.TextDocumentClientCapabilities
     ) -> None:
+        super().register_text_document_capability(cap)
         cap.code_action = lsp_type.CodeActionClientCapabilities(
             code_action_literal_support=lsp_type.ClientCodeActionLiteralOptions(
                 code_action_kind=lsp_type.ClientCodeActionKindOptions(

--- a/src/lsp_client/capability/request/completion.py
+++ b/src/lsp_client/capability/request/completion.py
@@ -36,6 +36,7 @@ class WithRequestCompletion(
     def register_text_document_capability(
         cls, cap: lsp_type.TextDocumentClientCapabilities
     ) -> None:
+        super().register_text_document_capability(cap)
         cap.completion = lsp_type.CompletionClientCapabilities(
             completion_item=lsp_type.ClientCompletionItemOptions(
                 snippet_support=True,

--- a/src/lsp_client/capability/request/declaration.py
+++ b/src/lsp_client/capability/request/declaration.py
@@ -33,6 +33,7 @@ class WithRequestDeclaration(
     def register_text_document_capability(
         cls, cap: lsp_type.TextDocumentClientCapabilities
     ) -> None:
+        super().register_text_document_capability(cap)
         cap.declaration = lsp_type.DeclarationClientCapabilities(
             link_support=True,
         )

--- a/src/lsp_client/capability/request/definition.py
+++ b/src/lsp_client/capability/request/definition.py
@@ -36,6 +36,7 @@ class WithRequestDefinition(
     def register_text_document_capability(
         cls, cap: lsp_type.TextDocumentClientCapabilities
     ) -> None:
+        super().register_text_document_capability(cap)
         cap.definition = lsp_type.DefinitionClientCapabilities(
             link_support=True,
         )

--- a/src/lsp_client/capability/request/document_symbol.py
+++ b/src/lsp_client/capability/request/document_symbol.py
@@ -33,6 +33,7 @@ class WithRequestDocumentSymbol(
     def register_text_document_capability(
         cls, cap: lsp_type.TextDocumentClientCapabilities
     ) -> None:
+        super().register_text_document_capability(cap)
         cap.document_symbol = lsp_type.DocumentSymbolClientCapabilities(
             symbol_kind=lsp_type.ClientSymbolKindOptions(
                 value_set=[*lsp_type.SymbolKind]

--- a/src/lsp_client/capability/request/hover.py
+++ b/src/lsp_client/capability/request/hover.py
@@ -29,6 +29,7 @@ class WithRequestHover(
     def register_text_document_capability(
         cls, cap: lsp_type.TextDocumentClientCapabilities
     ) -> None:
+        super().register_text_document_capability(cap)
         cap.hover = lsp_type.HoverClientCapabilities(
             content_format=[
                 lsp_type.MarkupKind.Markdown,

--- a/src/lsp_client/capability/request/implementation.py
+++ b/src/lsp_client/capability/request/implementation.py
@@ -33,6 +33,7 @@ class WithRequestImplementation(
     def register_text_document_capability(
         cls, cap: lsp_type.TextDocumentClientCapabilities
     ) -> None:
+        super().register_text_document_capability(cap)
         cap.implementation = lsp_type.ImplementationClientCapabilities(
             link_support=True,
         )

--- a/src/lsp_client/capability/request/inlay_hint.py
+++ b/src/lsp_client/capability/request/inlay_hint.py
@@ -34,6 +34,7 @@ class WithRequestInlayHint(
     def register_text_document_capability(
         cls, cap: lsp_type.TextDocumentClientCapabilities
     ) -> None:
+        super().register_text_document_capability(cap)
         cap.inlay_hint = lsp_type.InlayHintClientCapabilities(
             resolve_support=lsp_type.ClientInlayHintResolveOptions(
                 properties=[

--- a/src/lsp_client/capability/request/inline_value.py
+++ b/src/lsp_client/capability/request/inline_value.py
@@ -29,6 +29,7 @@ class WithRequestInlineValue(
     def register_text_document_capability(
         cls, cap: lsp_type.TextDocumentClientCapabilities
     ) -> None:
+        super().register_text_document_capability(cap)
         cap.inline_value = lsp_type.InlineValueClientCapabilities()
 
     @override

--- a/src/lsp_client/capability/request/reference.py
+++ b/src/lsp_client/capability/request/reference.py
@@ -29,6 +29,7 @@ class WithRequestReferences(
     def register_text_document_capability(
         cls, cap: lsp_type.TextDocumentClientCapabilities
     ) -> None:
+        super().register_text_document_capability(cap)
         cap.references = lsp_type.ReferenceClientCapabilities()
 
     @override

--- a/src/lsp_client/capability/request/signature_help.py
+++ b/src/lsp_client/capability/request/signature_help.py
@@ -31,6 +31,7 @@ class WithRequestSignatureHelp(
     def register_text_document_capability(
         cls, cap: lsp_type.TextDocumentClientCapabilities
     ) -> None:
+        super().register_text_document_capability(cap)
         cap.signature_help = lsp_type.SignatureHelpClientCapabilities(
             context_support=True,
             signature_information=lsp_type.ClientSignatureInformationOptions(

--- a/src/lsp_client/capability/request/type_definition.py
+++ b/src/lsp_client/capability/request/type_definition.py
@@ -33,6 +33,7 @@ class WithRequestTypeDefinition(
     def register_text_document_capability(
         cls, cap: lsp_type.TextDocumentClientCapabilities
     ) -> None:
+        super().register_text_document_capability(cap)
         cap.type_definition = lsp_type.TypeDefinitionClientCapabilities(
             link_support=True,
         )

--- a/src/lsp_client/capability/request/type_hierarchy.py
+++ b/src/lsp_client/capability/request/type_hierarchy.py
@@ -35,6 +35,7 @@ class WithRequestTypeHierarchy(
     def register_text_document_capability(
         cls, cap: lsp_type.TextDocumentClientCapabilities
     ) -> None:
+        super().register_text_document_capability(cap)
         cap.type_hierarchy = lsp_type.TypeHierarchyClientCapabilities()
 
     @override

--- a/src/lsp_client/capability/request/workspace_symbol.py
+++ b/src/lsp_client/capability/request/workspace_symbol.py
@@ -38,6 +38,7 @@ class WithRequestWorkspaceSymbol(
     def register_workspace_capability(
         cls, cap: lsp_type.WorkspaceClientCapabilities
     ) -> None:
+        super().register_workspace_capability(cap)
         cap.symbol = lsp_type.WorkspaceSymbolClientCapabilities(
             symbol_kind=lsp_type.ClientSymbolKindOptions(
                 value_set=[*lsp_type.SymbolKind]

--- a/src/lsp_client/utils/config.py
+++ b/src/lsp_client/utils/config.py
@@ -30,7 +30,10 @@ def deep_merge(base: dict[str, Any], update: dict[str, Any]) -> dict[str, Any]:
 
 
 def deep_get(d: dict, keys: Iterable) -> Any:
-    return reduce(getitem, keys, d)
+    try:
+        return reduce(getitem, keys, d)
+    except (KeyError, TypeError):
+        return None
 
 
 @runtime_checkable

--- a/tests/framework/lsp.py
+++ b/tests/framework/lsp.py
@@ -522,23 +522,23 @@ class DocumentSymbolsAssertion:
         def check_symbols(
             symbols: Sequence[lsp_type.SymbolInformation]
             | Sequence[lsp_type.DocumentSymbol],
+            found_names: list[str],
         ) -> bool:
-            found_names = []
             for sym in symbols:
                 if isinstance(sym, lsp_type.DocumentSymbol):
                     found_names.append(f"{sym.name} ({sym.kind})")
                     if sym.name == name and (kind is None or sym.kind == kind):
                         return True
-                    if sym.children and check_symbols(sym.children):
+                    if sym.children and check_symbols(sym.children, found_names):
                         return True
                 elif isinstance(sym, lsp_type.SymbolInformation):
                     found_names.append(f"{sym.name} ({sym.kind})")
                     if sym.name == name and (kind is None or sym.kind == kind):
                         return True
-            self._last_found_names = found_names
             return False
 
-        if not check_symbols(self.response):
+        self._last_found_names = []
+        if not check_symbols(self.response, self._last_found_names):
             print(f"Actually found: {self._last_found_names}")
             assert False, f"Symbol '{name}' not found"
 

--- a/tests/framework/lsp.py
+++ b/tests/framework/lsp.py
@@ -539,7 +539,7 @@ class DocumentSymbolsAssertion:
             return False
 
         if not check_symbols(self.response):
-            print(f"Actually found: {getattr(self, '_last_found_names', [])}")
+            print(f"Actually found: {self._last_found_names}")
             assert False, f"Symbol '{name}' not found"
 
 


### PR DESCRIPTION
## Summary
- Fixes a bug where LSP capability registration methods in mixins were shadowing each other without calling `super()`.
- Ensures all inherited capabilities (e.g., hierarchical document symbols, hover, sync) are correctly included in the client's `initialize` request.
- Improves `ConfigurationMap.get` and `deep_get` to return `None` instead of raising `KeyError` when configuration sections are missing, as required by the LSP spec.
- Adds debug logging to test assertions for easier troubleshooting of symbol discovery.