### PR TITLE
fix: configuration change notification not triggering

### DIFF
--- a/src/lsp_client/clients/basedpyright.py
+++ b/src/lsp_client/clients/basedpyright.py
@@ -132,6 +132,21 @@ class BasedpyrightClient(
         https://github.com/detachhead/basedpyright#settings
         """
         return {
+            "python": {
+                "analysis": {
+                    "autoImportCompletions": True,
+                    "autoSearchPaths": True,
+                    "diagnosticMode": "openFilesOnly",
+                    "indexing": True,
+                    "typeCheckingMode": "recommended",
+                    "inlayHints": {
+                        "variableTypes": True,
+                        "functionReturnTypes": True,
+                        "callArgumentNames": True,
+                        "pytestParameters": True,
+                    },
+                }
+            },
             "basedpyright": {
                 "analysis": {
                     "autoImportCompletions": True,
@@ -146,5 +161,5 @@ class BasedpyrightClient(
                         "pytestParameters": True,
                     },
                 }
-            }
+            },
         }


### PR DESCRIPTION
## Summary

Fixes critical bugs in `ConfigurationMap` that prevented `didChangeConfiguration` notifications from being sent to LSP servers, causing request timeouts.

## Root Cause

The callback in `ConfigurationMap._notify_change()` was invoked as `tg.soonify(callback)` instead of `tg.soonify(callback)(self)`, missing the required `ConfigurationMap` parameter. This caused the `didChangeConfiguration` notification to never be sent to the server.

## Changes

1. **config.py**: Fix callback parameter passing in `_notify_change()`
2. **config.py**: Fix `ScopeConfig` class definition and usage
3. **config.py**: Add missing return statement in `get()`
4. **basedpyright.py**: Add `python` section to default config (basedpyright requests both `python` and `basedpyright` sections)

## Impact

Before this fix, basedpyright would wait ~5 seconds before requesting configuration, causing `documentSymbol` and other requests to timeout. With this fix, configuration is properly notified immediately after initialization, and all requests work correctly.

## Testing

Verified that `test.py` now runs successfully without timeouts.