### PR TITLE
feat(protocol): add relative parameter to from_uri

### DIFF
--- a/tests/framework/lsp.py
+++ b/tests/framework/lsp.py
@@ -126,7 +126,9 @@ class DefinitionAssertion:
 
         match self.response:
             case lsp_type.Location() as loc:
-                actual_path = Path(self.interaction.client.from_uri(loc.uri))
+                actual_path = Path(
+                    self.interaction.client.from_uri(loc.uri, relative=False)
+                )
                 # Compare using resolved paths to handle symlinks properly
                 actual_resolved = actual_path.resolve()
                 expected_resolved = expected_path.resolve()
@@ -138,11 +140,15 @@ class DefinitionAssertion:
                 found = False
                 for loc in locs:
                     if isinstance(loc, lsp_type.Location):
-                        actual_path = Path(self.interaction.client.from_uri(loc.uri))
+                        actual_path = Path(
+                            self.interaction.client.from_uri(loc.uri, relative=False)
+                        )
                         actual_range = loc.range
                     elif isinstance(loc, lsp_type.LocationLink):
                         actual_path = Path(
-                            self.interaction.client.from_uri(loc.target_uri)
+                            self.interaction.client.from_uri(
+                                loc.target_uri, relative=False
+                            )
                         )
                         actual_range = loc.target_selection_range
                     else:
@@ -167,7 +173,9 @@ class DefinitionAssertion:
 
         match self.response:
             case lsp_type.Location() as loc:
-                actual_path = Path(self.interaction.client.from_uri(loc.uri))
+                actual_path = Path(
+                    self.interaction.client.from_uri(loc.uri, relative=False)
+                )
                 # Pyrefly may return resolved paths
                 # Compare using resolved paths to handle symlinks properly
                 actual_resolved = actual_path.resolve()
@@ -180,11 +188,15 @@ class DefinitionAssertion:
                 found = False
                 for loc in locs:
                     if isinstance(loc, lsp_type.Location):
-                        actual_path = Path(self.interaction.client.from_uri(loc.uri))
+                        actual_path = Path(
+                            self.interaction.client.from_uri(loc.uri, relative=False)
+                        )
                         actual_range = loc.range
                     elif isinstance(loc, lsp_type.LocationLink):
                         actual_path = Path(
-                            self.interaction.client.from_uri(loc.target_uri)
+                            self.interaction.client.from_uri(
+                                loc.target_uri, relative=False
+                            )
                         )
                         actual_range = loc.target_selection_range
                     else:
@@ -209,7 +221,9 @@ class DefinitionAssertion:
 
         match self.response:
             case lsp_type.Location() as loc:
-                actual_path = Path(self.interaction.client.from_uri(loc.uri))
+                actual_path = Path(
+                    self.interaction.client.from_uri(loc.uri, relative=False)
+                )
                 # Pyrefly may return resolved paths, so we need to handle symlinks
                 # Try to resolve both paths and compare
                 try:
@@ -234,11 +248,15 @@ class DefinitionAssertion:
                 found = False
                 for loc in locs:
                     if isinstance(loc, lsp_type.Location):
-                        actual_path = Path(self.interaction.client.from_uri(loc.uri))
+                        actual_path = Path(
+                            self.interaction.client.from_uri(loc.uri, relative=False)
+                        )
                         actual_range = loc.range
                     elif isinstance(loc, lsp_type.LocationLink):
                         actual_path = Path(
-                            self.interaction.client.from_uri(loc.target_uri)
+                            self.interaction.client.from_uri(
+                                loc.target_uri, relative=False
+                            )
                         )
                         actual_range = loc.target_selection_range
                     else:
@@ -276,7 +294,9 @@ class DefinitionAssertion:
 
         match self.response:
             case lsp_type.Location() as loc:
-                actual_path = Path(self.interaction.client.from_uri(loc.uri))
+                actual_path = Path(
+                    self.interaction.client.from_uri(loc.uri, relative=False)
+                )
                 # Compare using relative paths to handle symlinks
                 try:
                     actual_rel = actual_path.relative_to(
@@ -298,11 +318,15 @@ class DefinitionAssertion:
                 found = False
                 for loc in locs:
                     if isinstance(loc, lsp_type.Location):
-                        actual_path = Path(self.interaction.client.from_uri(loc.uri))
+                        actual_path = Path(
+                            self.interaction.client.from_uri(loc.uri, relative=False)
+                        )
                         actual_range = loc.range
                     elif isinstance(loc, lsp_type.LocationLink):
                         actual_path = Path(
-                            self.interaction.client.from_uri(loc.target_uri)
+                            self.interaction.client.from_uri(
+                                loc.target_uri, relative=False
+                            )
                         )
                         actual_range = loc.target_selection_range
                     else:
@@ -335,7 +359,9 @@ class DefinitionAssertion:
 
         match self.response:
             case lsp_type.Location() as loc:
-                actual_path = Path(self.interaction.client.from_uri(loc.uri))
+                actual_path = Path(
+                    self.interaction.client.from_uri(loc.uri, relative=False)
+                )
                 # Compare using relative paths to handle symlinks
                 try:
                     actual_rel = actual_path.relative_to(
@@ -357,11 +383,15 @@ class DefinitionAssertion:
                 found = False
                 for loc in locs:
                     if isinstance(loc, lsp_type.Location):
-                        actual_path = Path(self.interaction.client.from_uri(loc.uri))
+                        actual_path = Path(
+                            self.interaction.client.from_uri(loc.uri, relative=False)
+                        )
                         actual_range = loc.range
                     elif isinstance(loc, lsp_type.LocationLink):
                         actual_path = Path(
-                            self.interaction.client.from_uri(loc.target_uri)
+                            self.interaction.client.from_uri(
+                                loc.target_uri, relative=False
+                            )
                         )
                         actual_range = loc.target_selection_range
                     else:
@@ -394,7 +424,9 @@ class DefinitionAssertion:
 
         match self.response:
             case lsp_type.Location() as loc:
-                actual_path = Path(self.interaction.client.from_uri(loc.uri))
+                actual_path = Path(
+                    self.interaction.client.from_uri(loc.uri, relative=False)
+                )
                 # Compare using relative paths to handle symlinks
                 try:
                     actual_rel = actual_path.relative_to(
@@ -416,11 +448,15 @@ class DefinitionAssertion:
                 found = False
                 for loc in locs:
                     if isinstance(loc, lsp_type.Location):
-                        actual_path = Path(self.interaction.client.from_uri(loc.uri))
+                        actual_path = Path(
+                            self.interaction.client.from_uri(loc.uri, relative=False)
+                        )
                         actual_range = loc.range
                     elif isinstance(loc, lsp_type.LocationLink):
                         actual_path = Path(
-                            self.interaction.client.from_uri(loc.target_uri)
+                            self.interaction.client.from_uri(
+                                loc.target_uri, relative=False
+                            )
                         )
                         actual_range = loc.target_selection_range
                     else:
@@ -498,7 +534,7 @@ class ReferencesAssertion:
 
         found = False
         for loc in self.response:
-            actual_path = self.interaction.client.from_uri(loc.uri)
+            actual_path = self.interaction.client.from_uri(loc.uri, relative=False)
             if (
                 Path(actual_path).resolve() == expected_path
                 and loc.range == expected_range

--- a/tests/unit/test_protocol/test_client.py
+++ b/tests/unit/test_protocol/test_client.py
@@ -82,8 +82,28 @@ def test_capability_client_protocol_as_uri_multi_root():
 
 def test_capability_client_protocol_from_uri():
     workspace = Workspace()
+    path = Path("/test/project/file.py")
+    workspace[DEFAULT_WORKSPACE_DIR] = WorkspaceFolder(
+        uri=Path("/test/project").as_uri(), name=DEFAULT_WORKSPACE_DIR
+    )
     client = MockClient(workspace)
 
-    path = Path("/test/project/file.py")
     uri = path.as_uri()
-    assert client.from_uri(uri) == path
+    assert client.from_uri(uri) == Path("file.py")
+    assert client.from_uri(uri, relative=False) == path
+
+
+def test_capability_client_protocol_from_uri_multi_root():
+    workspace = Workspace()
+    path1 = Path("/test/root1")
+    path2 = Path("/test/root2")
+    workspace["root1"] = WorkspaceFolder(uri=path1.as_uri(), name="root1")
+    workspace["root2"] = WorkspaceFolder(uri=path2.as_uri(), name="root2")
+    client = MockClient(workspace)
+
+    uri1 = Path("/test/root1/file.py").as_uri()
+    uri2 = Path("/test/root2/file.py").as_uri()
+
+    assert client.from_uri(uri1, relative=True) == Path("root1/file.py")
+    assert client.from_uri(uri2, relative=True) == Path("root2/file.py")
+    assert client.from_uri(uri1, relative=False) == Path("/test/root1/file.py")


### PR DESCRIPTION
## Summary
- Added `relative` parameter to `CapabilityClientProtocol.from_uri` with a default value of `True`.
- When `relative=True`, `from_uri` returns the path relative to the workspace (supporting both single-root and multi-root workspaces).
- Updated internal callers and tests to ensure compatibility.
- Enforced keyword-only argument for `relative` to follow best practices.