### PR TITLE
feat: implement workspace file operation capabilities

### DIFF
--- a/src/lsp_client/capability/notification/__init__.py
+++ b/src/lsp_client/capability/notification/__init__.py
@@ -3,15 +3,24 @@ from __future__ import annotations
 from typing import Final
 
 from .did_change_configuration import WithNotifyDidChangeConfiguration
+from .did_create_files import WithNotifyDidCreateFiles
+from .did_delete_files import WithNotifyDidDeleteFiles
+from .did_rename_files import WithNotifyDidRenameFiles
 from .text_document_synchronize import WithNotifyTextDocumentSynchronize
 
 capabilities: Final = (
     WithNotifyDidChangeConfiguration,
+    WithNotifyDidCreateFiles,
+    WithNotifyDidRenameFiles,
+    WithNotifyDidDeleteFiles,
     WithNotifyTextDocumentSynchronize,
 )
 
 __all__ = [
     "WithNotifyDidChangeConfiguration",
+    "WithNotifyDidCreateFiles",
+    "WithNotifyDidDeleteFiles",
+    "WithNotifyDidRenameFiles",
     "WithNotifyTextDocumentSynchronize",
     "capabilities",
 ]

--- a/src/lsp_client/capability/notification/did_create_files.py
+++ b/src/lsp_client/capability/notification/did_create_files.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Protocol, override, runtime_checkable
+
+from lsp_client.protocol import CapabilityClientProtocol, WorkspaceCapabilityProtocol
+from lsp_client.utils.types import lsp_type
+
+
+@runtime_checkable
+class WithNotifyDidCreateFiles(
+    WorkspaceCapabilityProtocol,
+    CapabilityClientProtocol,
+    Protocol,
+):
+    """
+    `workspace/didCreateFiles` - https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_didCreateFiles
+    """
+
+    @override
+    @classmethod
+    def iter_methods(cls) -> Iterator[str]:
+        yield from super().iter_methods()
+        yield from (lsp_type.WORKSPACE_DID_CREATE_FILES,)
+
+    @override
+    @classmethod
+    def register_workspace_capability(
+        cls, cap: lsp_type.WorkspaceClientCapabilities
+    ) -> None:
+        super().register_workspace_capability(cap)
+        if cap.file_operations is None:
+            cap.file_operations = lsp_type.FileOperationClientCapabilities()
+        cap.file_operations.did_create = True
+
+    @override
+    @classmethod
+    def check_server_capability(cls, cap: lsp_type.ServerCapabilities) -> None:
+        super().check_server_capability(cap)
+
+    async def _notify_did_create_files(
+        self, params: lsp_type.CreateFilesParams
+    ) -> None:
+        return await self.notify(lsp_type.DidCreateFilesNotification(params=params))
+
+    async def notify_did_create_files(self, uris: list[str]) -> None:
+        """
+        Notify server that files have been created.
+
+        Args:
+            uris: List of file URIs that were created
+        """
+        return await self._notify_did_create_files(
+            lsp_type.CreateFilesParams(
+                files=[lsp_type.FileCreate(uri=uri) for uri in uris]
+            )
+        )

--- a/src/lsp_client/capability/notification/did_delete_files.py
+++ b/src/lsp_client/capability/notification/did_delete_files.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Protocol, override, runtime_checkable
+
+from lsp_client.protocol import CapabilityClientProtocol, WorkspaceCapabilityProtocol
+from lsp_client.utils.types import lsp_type
+
+
+@runtime_checkable
+class WithNotifyDidDeleteFiles(
+    WorkspaceCapabilityProtocol,
+    CapabilityClientProtocol,
+    Protocol,
+):
+    """
+    `workspace/didDeleteFiles` - https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_didDeleteFiles
+    """
+
+    @override
+    @classmethod
+    def iter_methods(cls) -> Iterator[str]:
+        yield from super().iter_methods()
+        yield from (lsp_type.WORKSPACE_DID_DELETE_FILES,)
+
+    @override
+    @classmethod
+    def register_workspace_capability(
+        cls, cap: lsp_type.WorkspaceClientCapabilities
+    ) -> None:
+        super().register_workspace_capability(cap)
+        if cap.file_operations is None:
+            cap.file_operations = lsp_type.FileOperationClientCapabilities()
+        cap.file_operations.did_delete = True
+
+    @override
+    @classmethod
+    def check_server_capability(cls, cap: lsp_type.ServerCapabilities) -> None:
+        super().check_server_capability(cap)
+
+    async def _notify_did_delete_files(
+        self, params: lsp_type.DeleteFilesParams
+    ) -> None:
+        return await self.notify(lsp_type.DidDeleteFilesNotification(params=params))
+
+    async def notify_did_delete_files(self, uris: list[str]) -> None:
+        """
+        Notify server that files have been deleted.
+
+        Args:
+            uris: List of file URIs that were deleted
+        """
+        return await self._notify_did_delete_files(
+            lsp_type.DeleteFilesParams(
+                files=[lsp_type.FileDelete(uri=uri) for uri in uris]
+            )
+        )

--- a/src/lsp_client/capability/notification/did_rename_files.py
+++ b/src/lsp_client/capability/notification/did_rename_files.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Protocol, override, runtime_checkable
+
+from lsp_client.protocol import CapabilityClientProtocol, WorkspaceCapabilityProtocol
+from lsp_client.utils.types import lsp_type
+
+
+@runtime_checkable
+class WithNotifyDidRenameFiles(
+    WorkspaceCapabilityProtocol,
+    CapabilityClientProtocol,
+    Protocol,
+):
+    """
+    `workspace/didRenameFiles` - https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_didRenameFiles
+    """
+
+    @override
+    @classmethod
+    def iter_methods(cls) -> Iterator[str]:
+        yield from super().iter_methods()
+        yield from (lsp_type.WORKSPACE_DID_RENAME_FILES,)
+
+    @override
+    @classmethod
+    def register_workspace_capability(
+        cls, cap: lsp_type.WorkspaceClientCapabilities
+    ) -> None:
+        super().register_workspace_capability(cap)
+        if cap.file_operations is None:
+            cap.file_operations = lsp_type.FileOperationClientCapabilities()
+        cap.file_operations.did_rename = True
+
+    @override
+    @classmethod
+    def check_server_capability(cls, cap: lsp_type.ServerCapabilities) -> None:
+        super().check_server_capability(cap)
+
+    async def _notify_did_rename_files(
+        self, params: lsp_type.RenameFilesParams
+    ) -> None:
+        return await self.notify(lsp_type.DidRenameFilesNotification(params=params))
+
+    async def notify_did_rename_files(
+        self, file_renames: list[tuple[str, str]]
+    ) -> None:
+        """
+        Notify server that files have been renamed.
+
+        Args:
+            file_renames: List of (old_uri, new_uri) tuples
+        """
+        return await self._notify_did_rename_files(
+            lsp_type.RenameFilesParams(
+                files=[
+                    lsp_type.FileRename(old_uri=old, new_uri=new)
+                    for old, new in file_renames
+                ]
+            )
+        )

--- a/src/lsp_client/capability/request/__init__.py
+++ b/src/lsp_client/capability/request/__init__.py
@@ -19,6 +19,9 @@ from .rename import WithRequestRename
 from .signature_help import WithRequestSignatureHelp
 from .type_definition import WithRequestTypeDefinition
 from .type_hierarchy import WithRequestTypeHierarchy
+from .will_create_files import WithRequestWillCreateFiles
+from .will_delete_files import WithRequestWillDeleteFiles
+from .will_rename_files import WithRequestWillRenameFiles
 from .workspace_symbol import WithRequestWorkspaceSymbol
 
 capabilities: Final = (
@@ -38,6 +41,9 @@ capabilities: Final = (
     WithRequestSignatureHelp,
     WithRequestTypeDefinition,
     WithRequestTypeHierarchy,
+    WithRequestWillCreateFiles,
+    WithRequestWillRenameFiles,
+    WithRequestWillDeleteFiles,
     WithWorkspaceDiagnostic,
     WithRequestWorkspaceSymbol,
 )
@@ -59,6 +65,9 @@ __all__ = [
     "WithRequestSignatureHelp",
     "WithRequestTypeDefinition",
     "WithRequestTypeHierarchy",
+    "WithRequestWillCreateFiles",
+    "WithRequestWillDeleteFiles",
+    "WithRequestWillRenameFiles",
     "WithRequestWorkspaceSymbol",
     "WithWorkspaceDiagnostic",
     "capabilities",

--- a/src/lsp_client/capability/request/will_create_files.py
+++ b/src/lsp_client/capability/request/will_create_files.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Protocol, override, runtime_checkable
+
+from lsp_client.jsonrpc.id import jsonrpc_uuid
+from lsp_client.protocol import CapabilityClientProtocol, WorkspaceCapabilityProtocol
+from lsp_client.utils.types import lsp_type
+from lsp_client.utils.workspace_edit import (
+    DocumentEditProtocol,
+    WorkspaceEditApplicator,
+)
+
+
+@runtime_checkable
+class WithRequestWillCreateFiles(
+    WorkspaceCapabilityProtocol,
+    CapabilityClientProtocol,
+    DocumentEditProtocol,
+    Protocol,
+):
+    """
+    `workspace/willCreateFiles` - https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_willCreateFiles
+    """
+
+    @override
+    @classmethod
+    def iter_methods(cls) -> Iterator[str]:
+        yield from super().iter_methods()
+        yield from (lsp_type.WORKSPACE_WILL_CREATE_FILES,)
+
+    @override
+    @classmethod
+    def register_workspace_capability(
+        cls, cap: lsp_type.WorkspaceClientCapabilities
+    ) -> None:
+        super().register_workspace_capability(cap)
+        if cap.file_operations is None:
+            cap.file_operations = lsp_type.FileOperationClientCapabilities()
+        cap.file_operations.will_create = True
+
+    @override
+    @classmethod
+    def check_server_capability(cls, cap: lsp_type.ServerCapabilities) -> None:
+        super().check_server_capability(cap)
+        # Server capability is optional - check if workspace.fileOperations.willCreate exists
+        if cap.workspace and cap.workspace.file_operations:
+            return  # Server supports it
+        # If not present, capability will not be used but won't fail
+
+    async def _request_will_create_files(
+        self, params: lsp_type.CreateFilesParams
+    ) -> lsp_type.WorkspaceEdit | None:
+        return await self.request(
+            lsp_type.WillCreateFilesRequest(
+                id=jsonrpc_uuid(),
+                params=params,
+            ),
+            schema=lsp_type.WillCreateFilesResponse,
+        )
+
+    async def request_will_create_files(
+        self, uris: list[str]
+    ) -> lsp_type.WorkspaceEdit | None:
+        """
+        Request workspace edits before creating files.
+
+        Args:
+            uris: List of file URIs to be created
+
+        Returns:
+            WorkspaceEdit to apply before creating files, or None
+        """
+        return await self._request_will_create_files(
+            lsp_type.CreateFilesParams(
+                files=[lsp_type.FileCreate(uri=uri) for uri in uris]
+            )
+        )
+
+    async def apply_workspace_edit(self, edit: lsp_type.WorkspaceEdit) -> None:
+        """
+        Apply workspace edit to documents.
+
+        Args:
+            edit: Workspace edit to apply
+        """
+        applicator = WorkspaceEditApplicator(client=self)
+        await applicator.apply_workspace_edit(edit)

--- a/src/lsp_client/capability/request/will_delete_files.py
+++ b/src/lsp_client/capability/request/will_delete_files.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Protocol, override, runtime_checkable
+
+from lsp_client.jsonrpc.id import jsonrpc_uuid
+from lsp_client.protocol import CapabilityClientProtocol, WorkspaceCapabilityProtocol
+from lsp_client.utils.types import lsp_type
+from lsp_client.utils.workspace_edit import (
+    DocumentEditProtocol,
+    WorkspaceEditApplicator,
+)
+
+
+@runtime_checkable
+class WithRequestWillDeleteFiles(
+    WorkspaceCapabilityProtocol,
+    CapabilityClientProtocol,
+    DocumentEditProtocol,
+    Protocol,
+):
+    """
+    `workspace/willDeleteFiles` - https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_willDeleteFiles
+    """
+
+    @override
+    @classmethod
+    def iter_methods(cls) -> Iterator[str]:
+        yield from super().iter_methods()
+        yield from (lsp_type.WORKSPACE_WILL_DELETE_FILES,)
+
+    @override
+    @classmethod
+    def register_workspace_capability(
+        cls, cap: lsp_type.WorkspaceClientCapabilities
+    ) -> None:
+        super().register_workspace_capability(cap)
+        if cap.file_operations is None:
+            cap.file_operations = lsp_type.FileOperationClientCapabilities()
+        cap.file_operations.will_delete = True
+
+    @override
+    @classmethod
+    def check_server_capability(cls, cap: lsp_type.ServerCapabilities) -> None:
+        super().check_server_capability(cap)
+        # Server capability is optional
+        if cap.workspace and cap.workspace.file_operations:
+            return
+
+    async def _request_will_delete_files(
+        self, params: lsp_type.DeleteFilesParams
+    ) -> lsp_type.WorkspaceEdit | None:
+        return await self.request(
+            lsp_type.WillDeleteFilesRequest(
+                id=jsonrpc_uuid(),
+                params=params,
+            ),
+            schema=lsp_type.WillDeleteFilesResponse,
+        )
+
+    async def request_will_delete_files(
+        self, uris: list[str]
+    ) -> lsp_type.WorkspaceEdit | None:
+        """
+        Request workspace edits before deleting files.
+
+        Args:
+            uris: List of file URIs to be deleted
+
+        Returns:
+            WorkspaceEdit to apply before deleting files, or None
+        """
+        return await self._request_will_delete_files(
+            lsp_type.DeleteFilesParams(
+                files=[lsp_type.FileDelete(uri=uri) for uri in uris]
+            )
+        )
+
+    async def apply_workspace_edit(self, edit: lsp_type.WorkspaceEdit) -> None:
+        """
+        Apply workspace edit to documents.
+
+        Args:
+            edit: Workspace edit to apply
+        """
+        applicator = WorkspaceEditApplicator(client=self)
+        await applicator.apply_workspace_edit(edit)

--- a/src/lsp_client/capability/request/will_rename_files.py
+++ b/src/lsp_client/capability/request/will_rename_files.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Protocol, override, runtime_checkable
+
+from lsp_client.jsonrpc.id import jsonrpc_uuid
+from lsp_client.protocol import CapabilityClientProtocol, WorkspaceCapabilityProtocol
+from lsp_client.utils.types import lsp_type
+from lsp_client.utils.workspace_edit import (
+    DocumentEditProtocol,
+    WorkspaceEditApplicator,
+)
+
+
+@runtime_checkable
+class WithRequestWillRenameFiles(
+    WorkspaceCapabilityProtocol,
+    CapabilityClientProtocol,
+    DocumentEditProtocol,
+    Protocol,
+):
+    """
+    `workspace/willRenameFiles` - https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_willRenameFiles
+    """
+
+    @override
+    @classmethod
+    def iter_methods(cls) -> Iterator[str]:
+        yield from super().iter_methods()
+        yield from (lsp_type.WORKSPACE_WILL_RENAME_FILES,)
+
+    @override
+    @classmethod
+    def register_workspace_capability(
+        cls, cap: lsp_type.WorkspaceClientCapabilities
+    ) -> None:
+        super().register_workspace_capability(cap)
+        if cap.file_operations is None:
+            cap.file_operations = lsp_type.FileOperationClientCapabilities()
+        cap.file_operations.will_rename = True
+
+    @override
+    @classmethod
+    def check_server_capability(cls, cap: lsp_type.ServerCapabilities) -> None:
+        super().check_server_capability(cap)
+        # Server capability is optional
+        if cap.workspace and cap.workspace.file_operations:
+            return
+
+    async def _request_will_rename_files(
+        self, params: lsp_type.RenameFilesParams
+    ) -> lsp_type.WorkspaceEdit | None:
+        return await self.request(
+            lsp_type.WillRenameFilesRequest(
+                id=jsonrpc_uuid(),
+                params=params,
+            ),
+            schema=lsp_type.WillRenameFilesResponse,
+        )
+
+    async def request_will_rename_files(
+        self, file_renames: list[tuple[str, str]]
+    ) -> lsp_type.WorkspaceEdit | None:
+        """
+        Request workspace edits before renaming files.
+
+        Args:
+            file_renames: List of (old_uri, new_uri) tuples
+
+        Returns:
+            WorkspaceEdit to apply before renaming files, or None
+        """
+        return await self._request_will_rename_files(
+            lsp_type.RenameFilesParams(
+                files=[
+                    lsp_type.FileRename(old_uri=old, new_uri=new)
+                    for old, new in file_renames
+                ]
+            )
+        )
+
+    async def apply_workspace_edit(self, edit: lsp_type.WorkspaceEdit) -> None:
+        """
+        Apply workspace edit to documents.
+
+        Args:
+            edit: Workspace edit to apply
+        """
+        applicator = WorkspaceEditApplicator(client=self)
+        await applicator.apply_workspace_edit(edit)

--- a/src/lsp_client/clients/pyright.py
+++ b/src/lsp_client/clients/pyright.py
@@ -11,6 +11,9 @@ from loguru import logger
 
 from lsp_client.capability.notification import (
     WithNotifyDidChangeConfiguration,
+    WithNotifyDidCreateFiles,
+    WithNotifyDidDeleteFiles,
+    WithNotifyDidRenameFiles,
 )
 from lsp_client.capability.request import (
     WithRequestCallHierarchy,
@@ -24,6 +27,9 @@ from lsp_client.capability.request import (
     WithRequestRename,
     WithRequestSignatureHelp,
     WithRequestTypeDefinition,
+    WithRequestWillCreateFiles,
+    WithRequestWillDeleteFiles,
+    WithRequestWillRenameFiles,
     WithRequestWorkspaceSymbol,
 )
 from lsp_client.capability.server_notification import (
@@ -79,6 +85,9 @@ PyrightLocalServer = partial(
 class PyrightClient(
     PythonClientBase,
     WithNotifyDidChangeConfiguration,
+    WithNotifyDidCreateFiles,
+    WithNotifyDidRenameFiles,
+    WithNotifyDidDeleteFiles,
     WithRequestCallHierarchy,
     WithRequestCodeAction,
     WithRequestCompletion,
@@ -90,6 +99,9 @@ class PyrightClient(
     WithRequestRename,
     WithRequestSignatureHelp,
     WithRequestTypeDefinition,
+    WithRequestWillCreateFiles,
+    WithRequestWillRenameFiles,
+    WithRequestWillDeleteFiles,
     WithRequestWorkspaceSymbol,
     WithReceiveLogMessage,
     WithReceiveLogTrace,

--- a/src/lsp_client/clients/rust_analyzer.py
+++ b/src/lsp_client/clients/rust_analyzer.py
@@ -11,6 +11,9 @@ from loguru import logger
 
 from lsp_client.capability.notification import (
     WithNotifyDidChangeConfiguration,
+    WithNotifyDidCreateFiles,
+    WithNotifyDidDeleteFiles,
+    WithNotifyDidRenameFiles,
 )
 from lsp_client.capability.request import (
     WithDocumentDiagnostic,
@@ -26,6 +29,9 @@ from lsp_client.capability.request import (
     WithRequestReferences,
     WithRequestSignatureHelp,
     WithRequestTypeDefinition,
+    WithRequestWillCreateFiles,
+    WithRequestWillDeleteFiles,
+    WithRequestWillRenameFiles,
     WithRequestWorkspaceSymbol,
 )
 from lsp_client.capability.server_notification import (
@@ -80,6 +86,9 @@ RustAnalyzerLocalServer = partial(
 class RustAnalyzerClient(
     RustClientBase,
     WithNotifyDidChangeConfiguration,
+    WithNotifyDidCreateFiles,
+    WithNotifyDidRenameFiles,
+    WithNotifyDidDeleteFiles,
     WithRequestCallHierarchy,
     WithRequestCodeAction,
     WithRequestCompletion,
@@ -93,6 +102,9 @@ class RustAnalyzerClient(
     WithRequestReferences,
     WithRequestSignatureHelp,
     WithRequestTypeDefinition,
+    WithRequestWillCreateFiles,
+    WithRequestWillRenameFiles,
+    WithRequestWillDeleteFiles,
     WithRequestWorkspaceSymbol,
     WithReceiveLogMessage,
     WithReceiveLogTrace,

--- a/src/lsp_client/utils/file_operations.py
+++ b/src/lsp_client/utils/file_operations.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from typing import cast
+
+import anyio
+
+from lsp_client.capability.notification.did_create_files import WithNotifyDidCreateFiles
+from lsp_client.capability.notification.did_delete_files import WithNotifyDidDeleteFiles
+from lsp_client.capability.notification.did_rename_files import WithNotifyDidRenameFiles
+from lsp_client.capability.request.will_create_files import WithRequestWillCreateFiles
+from lsp_client.capability.request.will_delete_files import WithRequestWillDeleteFiles
+from lsp_client.capability.request.will_rename_files import WithRequestWillRenameFiles
+from lsp_client.client.abc import Client
+from lsp_client.utils.uri import from_local_uri
+
+
+async def create_files_with_server(client: Client, uris: list[str]) -> None:
+    """
+    Create files with full LSP integration.
+
+    1. Call willCreateFiles to get edits
+    2. Apply workspace edits
+    3. Create the files (if they don't exist)
+    4. Call didCreateFiles notification
+    """
+    if isinstance(client, WithRequestWillCreateFiles):
+        c = cast(WithRequestWillCreateFiles, client)
+        edit = await c.request_will_create_files(uris)
+        if edit:
+            await c.apply_workspace_edit(edit)
+
+    for uri in uris:
+        path = from_local_uri(uri)
+        anyio_path = anyio.Path(path)
+        if not await anyio_path.exists():
+            await anyio_path.parent.mkdir(parents=True, exist_ok=True)
+            await anyio_path.write_text("")
+
+    if isinstance(client, WithNotifyDidCreateFiles):
+        await cast(WithNotifyDidCreateFiles, client).notify_did_create_files(uris)
+
+
+async def rename_files_with_server(
+    client: Client, file_renames: list[tuple[str, str]]
+) -> None:
+    """
+    Rename files with full LSP integration.
+
+    1. Call willRenameFiles to get edits
+    2. Apply workspace edits
+    3. Rename the files
+    4. Call didRenameFiles notification
+    """
+    if isinstance(client, WithRequestWillRenameFiles):
+        c = cast(WithRequestWillRenameFiles, client)
+        edit = await c.request_will_rename_files(file_renames)
+        if edit:
+            await c.apply_workspace_edit(edit)
+
+    for old_uri, new_uri in file_renames:
+        old_path = anyio.Path(from_local_uri(old_uri))
+        new_path = anyio.Path(from_local_uri(new_uri))
+        if await old_path.exists():
+            await new_path.parent.mkdir(parents=True, exist_ok=True)
+            await old_path.rename(new_path)
+
+    if isinstance(client, WithNotifyDidRenameFiles):
+        await cast(WithNotifyDidRenameFiles, client).notify_did_rename_files(
+            file_renames
+        )
+
+
+async def delete_files_with_server(client: Client, uris: list[str]) -> None:
+    """
+    Delete files with full LSP integration.
+
+    1. Call willDeleteFiles to get edits
+    2. Apply workspace edits
+    3. Delete the files
+    4. Call didDeleteFiles notification
+    """
+    if isinstance(client, WithRequestWillDeleteFiles):
+        c = cast(WithRequestWillDeleteFiles, client)
+        edit = await c.request_will_delete_files(uris)
+        if edit:
+            await c.apply_workspace_edit(edit)
+
+    for uri in uris:
+        path = anyio.Path(from_local_uri(uri))
+        if await path.exists():
+            if await path.is_dir():
+                import shutil
+
+                shutil.rmtree(path)
+            else:
+                await path.unlink()
+
+    if isinstance(client, WithNotifyDidDeleteFiles):
+        await cast(WithNotifyDidDeleteFiles, client).notify_did_delete_files(uris)

--- a/tests/integration/test_workspace_file_operations.py
+++ b/tests/integration/test_workspace_file_operations.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from lsp_client.capability.notification.did_create_files import WithNotifyDidCreateFiles
+from lsp_client.capability.notification.did_delete_files import WithNotifyDidDeleteFiles
+from lsp_client.capability.notification.did_rename_files import WithNotifyDidRenameFiles
+from lsp_client.capability.request.will_create_files import WithRequestWillCreateFiles
+from lsp_client.capability.request.will_delete_files import WithRequestWillDeleteFiles
+from lsp_client.capability.request.will_rename_files import WithRequestWillRenameFiles
+from lsp_client.client.abc import Client
+from lsp_client.server import DefaultServers
+from lsp_client.utils.types import lsp_type
+
+
+class WorkspaceFileOpClient(
+    Client,
+    WithNotifyDidCreateFiles,
+    WithNotifyDidRenameFiles,
+    WithNotifyDidDeleteFiles,
+    WithRequestWillCreateFiles,
+    WithRequestWillRenameFiles,
+    WithRequestWillDeleteFiles,
+):
+    @classmethod
+    def create_default_servers(cls):
+        from unittest.mock import create_autospec
+
+        from lsp_client.server.container import ContainerServer
+        from lsp_client.server.local import LocalServer
+
+        return DefaultServers(
+            local=create_autospec(LocalServer, instance=True),
+            container=create_autospec(ContainerServer, instance=True),
+        )
+
+    @classmethod
+    def get_language_config(cls):
+        from lsp_client.protocol.lang import LanguageConfig
+
+        return LanguageConfig(
+            kind=lsp_type.LanguageKind.Python, suffixes=[".py"], project_files=[]
+        )
+
+    def check_server_compatibility(self, info):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_workspace_file_operations_integration():
+    # Mock server behavior
+    mock_server = AsyncMock()
+    mock_server.wait_requests_completed = AsyncMock()
+
+    # Initialize response
+    _ = lsp_type.InitializeResult(
+        capabilities=lsp_type.ServerCapabilities(
+            workspace=lsp_type.WorkspaceOptions(
+                file_operations=lsp_type.FileOperationOptions(
+                    will_create=lsp_type.FileOperationRegistrationOptions(filters=[]),
+                    did_create=lsp_type.FileOperationRegistrationOptions(filters=[]),
+                )
+            )
+        )
+    )
+
+    mock_server.request.side_effect = [
+        # Response for initialize
+        {
+            "jsonrpc": "2.0",
+            "id": "initialize",
+            "result": {
+                "capabilities": {
+                    "textDocumentSync": 1,
+                    "workspace": {
+                        "fileOperations": {
+                            "willCreate": {"filters": []},
+                            "didCreate": {"filters": []},
+                        }
+                    },
+                }
+            },
+        },
+        # Response for willCreateFiles
+        {"jsonrpc": "2.0", "id": "1", "result": None},
+        # Response for shutdown
+        {"jsonrpc": "2.0", "id": "shutdown", "result": None},
+    ]
+
+    with patch("lsp_client.client.abc.Client.run_server") as mock_run:
+        from contextlib import asynccontextmanager
+
+        @asynccontextmanager
+        async def mock_run_server():
+            import anyio
+
+            s, r = anyio.create_memory_object_stream(128)
+            try:
+                yield mock_server, r
+            finally:
+                s.close()
+
+        mock_run.side_effect = mock_run_server
+
+        async with WorkspaceFileOpClient(workspace=Path.cwd()) as client:
+            # Test willCreateFiles
+            uris = ["file:///test.py"]
+            await client.request_will_create_files(uris)
+
+            # Test didCreateFiles
+            await client.notify_did_create_files(uris)
+
+    # Verify initialize was called with correct capabilities
+    init_call = mock_server.request.call_args_list[0][0][0]
+    assert init_call["method"] == "initialize"
+    caps = init_call["params"]["capabilities"]["workspace"]["fileOperations"]
+    assert caps["willCreate"] is True
+    assert caps["didCreate"] is True
+    assert caps["willRename"] is True
+    assert caps["didRename"] is True
+    assert caps["willDelete"] is True
+    assert caps["didDelete"] is True
+
+    # Verify willCreateFiles request
+    will_create_call = mock_server.request.call_args_list[1][0][0]
+    assert will_create_call["method"] == "workspace/willCreateFiles"
+    assert will_create_call["params"]["files"][0]["uri"] == uris[0]
+
+    # Verify didCreateFiles notification
+    # index 0 is 'initialized', index 1 is 'workspace/didCreateFiles'
+    did_create_call = mock_server.notify.call_args_list[1][0][0]
+    assert did_create_call["method"] == "workspace/didCreateFiles"
+    assert did_create_call["params"]["files"][0]["uri"] == uris[0]

--- a/tests/unit/test_capability/test_workspace_file_operations.py
+++ b/tests/unit/test_capability/test_workspace_file_operations.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from lsp_client.capability.build import build_client_capabilities
+from lsp_client.capability.notification.did_create_files import WithNotifyDidCreateFiles
+from lsp_client.capability.notification.did_delete_files import WithNotifyDidDeleteFiles
+from lsp_client.capability.notification.did_rename_files import WithNotifyDidRenameFiles
+from lsp_client.capability.request.will_create_files import WithRequestWillCreateFiles
+from lsp_client.capability.request.will_delete_files import WithRequestWillDeleteFiles
+from lsp_client.capability.request.will_rename_files import WithRequestWillRenameFiles
+
+
+def test_mixin_did_create_files():
+    class Client(WithNotifyDidCreateFiles):
+        pass
+
+    capabilities = build_client_capabilities(Client)
+    assert capabilities.workspace is not None
+    assert capabilities.workspace.file_operations is not None
+    assert capabilities.workspace.file_operations.did_create is True
+
+
+def test_mixin_did_rename_files():
+    class Client(WithNotifyDidRenameFiles):
+        pass
+
+    capabilities = build_client_capabilities(Client)
+    assert capabilities.workspace is not None
+    assert capabilities.workspace.file_operations is not None
+    assert capabilities.workspace.file_operations.did_rename is True
+
+
+def test_mixin_did_delete_files():
+    class Client(WithNotifyDidDeleteFiles):
+        pass
+
+    capabilities = build_client_capabilities(Client)
+    assert capabilities.workspace is not None
+    assert capabilities.workspace.file_operations is not None
+    assert capabilities.workspace.file_operations.did_delete is True
+
+
+def test_mixin_will_create_files():
+    class Client(WithRequestWillCreateFiles):
+        pass
+
+    capabilities = build_client_capabilities(Client)
+    assert capabilities.workspace is not None
+    assert capabilities.workspace.file_operations is not None
+    assert capabilities.workspace.file_operations.will_create is True
+
+
+def test_mixin_will_rename_files():
+    class Client(WithRequestWillRenameFiles):
+        pass
+
+    capabilities = build_client_capabilities(Client)
+    assert capabilities.workspace is not None
+    assert capabilities.workspace.file_operations is not None
+    assert capabilities.workspace.file_operations.will_rename is True
+
+
+def test_mixin_will_delete_files():
+    class Client(WithRequestWillDeleteFiles):
+        pass
+
+    capabilities = build_client_capabilities(Client)
+    assert capabilities.workspace is not None
+    assert capabilities.workspace.file_operations is not None
+    assert capabilities.workspace.file_operations.will_delete is True

--- a/tests/unit/test_capability/test_workspace_file_operations_logic.py
+++ b/tests/unit/test_capability/test_workspace_file_operations_logic.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from lsprotocol import types as lsp_type
+
+from lsp_client.capability.notification.did_create_files import WithNotifyDidCreateFiles
+from lsp_client.capability.notification.did_delete_files import WithNotifyDidDeleteFiles
+from lsp_client.capability.notification.did_rename_files import WithNotifyDidRenameFiles
+from lsp_client.capability.request.will_create_files import WithRequestWillCreateFiles
+from lsp_client.capability.request.will_delete_files import WithRequestWillDeleteFiles
+from lsp_client.capability.request.will_rename_files import WithRequestWillRenameFiles
+
+
+class MockClient:
+    def __init__(self):
+        self.request_mock = AsyncMock()
+        self.notify_mock = AsyncMock()
+        self.get_workspace_mock = MagicMock()
+        self.get_config_map_mock = MagicMock()
+        self._document_state = MagicMock()
+
+    def get_workspace(self):
+        return self.get_workspace_mock()
+
+    def get_config_map(self):
+        return self.get_config_map_mock()
+
+    @classmethod
+    def get_language_config(cls):
+        return MagicMock()
+
+    @asynccontextmanager
+    async def open_files(self, *file_paths):
+        yield
+
+    async def read_file(self, file_path):
+        return ""
+
+    async def write_file(self, uri, content):
+        pass
+
+    def from_uri(self, uri, *, relative=True):
+        return MagicMock()
+
+    async def request(self, req, schema):
+        return await self.request_mock(req, schema)
+
+    async def notify(self, msg):
+        await self.notify_mock(msg)
+
+
+@pytest.mark.asyncio
+async def test_request_will_create_files():
+    class TestClient(MockClient, WithRequestWillCreateFiles):
+        pass
+
+    client = TestClient()
+    uris = ["file:///test.py"]
+    await client.request_will_create_files(uris)
+
+    client.request_mock.assert_called_once()
+    call_args = client.request_mock.call_args[0][0]
+    assert isinstance(call_args, lsp_type.WillCreateFilesRequest)
+    assert call_args.params.files[0].uri == uris[0]
+
+
+@pytest.mark.asyncio
+async def test_request_will_rename_files():
+    class TestClient(MockClient, WithRequestWillRenameFiles):
+        pass
+
+    client = TestClient()
+    renames = [("file:///old.py", "file:///new.py")]
+    await client.request_will_rename_files(renames)
+
+    client.request_mock.assert_called_once()
+    call_args = client.request_mock.call_args[0][0]
+    assert isinstance(call_args, lsp_type.WillRenameFilesRequest)
+    assert call_args.params.files[0].old_uri == renames[0][0]
+    assert call_args.params.files[0].new_uri == renames[0][1]
+
+
+@pytest.mark.asyncio
+async def test_request_will_delete_files():
+    class TestClient(MockClient, WithRequestWillDeleteFiles):
+        pass
+
+    client = TestClient()
+    uris = ["file:///test.py"]
+    await client.request_will_delete_files(uris)
+
+    client.request_mock.assert_called_once()
+    call_args = client.request_mock.call_args[0][0]
+    assert isinstance(call_args, lsp_type.WillDeleteFilesRequest)
+    assert call_args.params.files[0].uri == uris[0]
+
+
+@pytest.mark.asyncio
+async def test_notify_did_create_files():
+    class TestClient(MockClient, WithNotifyDidCreateFiles):
+        pass
+
+    client = TestClient()
+    uris = ["file:///test.py"]
+    await client.notify_did_create_files(uris)
+
+    client.notify_mock.assert_called_once()
+    call_args = client.notify_mock.call_args[0][0]
+    assert isinstance(call_args, lsp_type.DidCreateFilesNotification)
+    assert call_args.params.files[0].uri == uris[0]
+
+
+@pytest.mark.asyncio
+async def test_notify_did_rename_files():
+    class TestClient(MockClient, WithNotifyDidRenameFiles):
+        pass
+
+    client = TestClient()
+    renames = [("file:///old.py", "file:///new.py")]
+    await client.notify_did_rename_files(renames)
+
+    client.notify_mock.assert_called_once()
+    call_args = client.notify_mock.call_args[0][0]
+    assert isinstance(call_args, lsp_type.DidRenameFilesNotification)
+    assert call_args.params.files[0].old_uri == renames[0][0]
+    assert call_args.params.files[0].new_uri == renames[0][1]
+
+
+@pytest.mark.asyncio
+async def test_notify_did_delete_files():
+    class TestClient(MockClient, WithNotifyDidDeleteFiles):
+        pass
+
+    client = TestClient()
+    uris = ["file:///test.py"]
+    await client.notify_did_delete_files(uris)
+
+    client.notify_mock.assert_called_once()
+    call_args = client.notify_mock.call_args[0][0]
+    assert isinstance(call_args, lsp_type.DidDeleteFilesNotification)
+    assert call_args.params.files[0].uri == uris[0]


### PR DESCRIPTION
## Summary
Implemented LSP 3.17 workspace file operation capabilities (Phase 1-3 and 6 as per plan).

## Changes
- Implemented `workspace/willCreateFiles`, `workspace/willRenameFiles`, `workspace/willDeleteFiles` requests.
- Implemented `workspace/didCreateFiles`, `workspace/didRenameFiles`, `workspace/didDeleteFiles` notifications.
- Integrated new capabilities into `PyrightClient` and `RustAnalyzerClient`.
- Added high-level helpers in `lsp_client.utils.file_operations` for atomic file operations with LSP integration.
- Added comprehensive unit and integration tests.

## Verification
- All tests passed: `uv run python -m pytest tests/unit/test_capability/test_workspace_file_operations* tests/integration/test_workspace_file_operations.py`
- Linting and type checking passed.