### PR TITLE
fix: resolve Basedpyright rename issue and add E2E tests

### DIFF
--- a/src/lsp_client/capability/request/rename.py
+++ b/src/lsp_client/capability/request/rename.py
@@ -149,10 +149,19 @@ class WithRequestRename(
             EditApplicationError: If rename edit cannot be applied
             OSError: If file I/O operations fail
         """
-        workspace_edit = await self.request_rename_edits(file_path, position, new_name)
+        async with self.open_files(file_path):
+            workspace_edit = await self._request_rename(
+                lsp_type.RenameParams(
+                    text_document=lsp_type.TextDocumentIdentifier(
+                        uri=self.as_uri(file_path)
+                    ),
+                    position=position,
+                    new_name=new_name,
+                )
+            )
 
-        if workspace_edit is None:
-            return False
+            if workspace_edit is None:
+                return False
 
-        await self.apply_workspace_edit(workspace_edit)
-        return True
+            await self.apply_workspace_edit(workspace_edit)
+            return True

--- a/src/lsp_client/clients/basedpyright.py
+++ b/src/lsp_client/clients/basedpyright.py
@@ -12,6 +12,9 @@ from loguru import logger
 
 from lsp_client.capability.notification import (
     WithNotifyDidChangeConfiguration,
+    WithNotifyDidCreateFiles,
+    WithNotifyDidDeleteFiles,
+    WithNotifyDidRenameFiles,
 )
 from lsp_client.capability.request import (
     WithRequestCallHierarchy,
@@ -22,8 +25,12 @@ from lsp_client.capability.request import (
     WithRequestDocumentSymbol,
     WithRequestHover,
     WithRequestReferences,
+    WithRequestRename,
     WithRequestSignatureHelp,
     WithRequestTypeDefinition,
+    WithRequestWillCreateFiles,
+    WithRequestWillDeleteFiles,
+    WithRequestWillRenameFiles,
     WithRequestWorkspaceSymbol,
 )
 from lsp_client.capability.server_notification import (
@@ -86,6 +93,9 @@ BasedpyrightLocalServer = partial(
 class BasedpyrightClient(
     PythonClientBase,
     WithNotifyDidChangeConfiguration,
+    WithNotifyDidCreateFiles,
+    WithNotifyDidRenameFiles,
+    WithNotifyDidDeleteFiles,
     WithRequestCallHierarchy,
     WithRequestCodeAction,
     WithRequestCompletion,
@@ -94,8 +104,12 @@ class BasedpyrightClient(
     WithRequestDocumentSymbol,
     WithRequestHover,
     WithRequestReferences,
+    WithRequestRename,
     WithRequestSignatureHelp,
     WithRequestTypeDefinition,
+    WithRequestWillCreateFiles,
+    WithRequestWillRenameFiles,
+    WithRequestWillDeleteFiles,
     WithRequestWorkspaceSymbol,
     WithReceiveLogMessage,
     WithReceiveLogTrace,

--- a/src/lsp_client/utils/workspace_edit.py
+++ b/src/lsp_client/utils/workspace_edit.py
@@ -201,8 +201,9 @@ class WorkspaceEditApplicator:
         new_content = apply_text_edits(content, edit.edits)
         await self.client.write_file(uri, new_content)
 
-        # Update document state
-        _ = self.client.get_document_state().update_content(uri, new_content)
+        # Update document state if tracked
+        with suppress(KeyError):
+            _ = self.client.get_document_state().update_content(uri, new_content)
 
     async def _apply_changes(
         self, changes: Mapping[str, Sequence[lsp_type.TextEdit]]

--- a/tests/e2e/test_basedpyright_rename.py
+++ b/tests/e2e/test_basedpyright_rename.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import pytest
+
+from lsp_client.clients.basedpyright import BasedpyrightClient
+from lsp_client.utils.types import Position
+from tests.framework.lsp import lsp_interaction_context
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_basedpyright_rename():
+    async with lsp_interaction_context(BasedpyrightClient) as interaction:  # ty: ignore[invalid-argument-type]
+        content = "def my_func():\n    pass\n\nmy_func()\n"
+        file_path = "test_rename.py"
+        full_path = await interaction.create_file(file_path, content)
+
+        # We don't need to manually open the file because request_rename handles it now,
+        # but in a real scenario it might already be open.
+        success = await interaction.client.request_rename(  # ty: ignore[unresolved-attribute]
+            full_path, Position(line=0, character=4), "new_func"
+        )
+
+        assert success is True
+
+        updated_content = full_path.read_text()
+        assert "def new_func():" in updated_content
+        assert "new_func()" in updated_content
+        assert "my_func" not in updated_content
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_basedpyright_rename_multiple_files():
+    async with lsp_interaction_context(BasedpyrightClient) as interaction:  # ty: ignore[invalid-argument-type]
+        # File 1: defines a function
+        content1 = "def my_global_func():\n    pass\n"
+        path1 = await interaction.create_file("lib.py", content1)
+
+        # File 2: uses the function
+        content2 = "from lib import my_global_func\nmy_global_func()\n"
+        path2 = await interaction.create_file("main.py", content2)
+
+        import anyio
+
+        await anyio.sleep(2)  # Wait for indexing
+
+        # Perform rename in lib.py
+
+        success = await interaction.client.request_rename(  # ty: ignore[unresolved-attribute]
+            path1, Position(line=0, character=4), "new_global_func"
+        )
+
+        assert success is True
+
+        # Verify lib.py
+        assert "def new_global_func():" in path1.read_text()
+
+        # Verify main.py (cross-file rename)
+        main_content = path2.read_text()
+        assert "from lib import new_global_func" in main_content
+        assert "new_global_func()" in main_content
+        assert "my_global_func" not in main_content

--- a/tests/e2e/test_basedpyright_rename.py
+++ b/tests/e2e/test_basedpyright_rename.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import anyio
 import pytest
 
 from lsp_client.clients.basedpyright import BasedpyrightClient
@@ -40,8 +41,6 @@ async def test_basedpyright_rename_multiple_files():
         # File 2: uses the function
         content2 = "from lib import my_global_func\nmy_global_func()\n"
         path2 = await interaction.create_file("main.py", content2)
-
-        import anyio
 
         await anyio.sleep(2)  # Wait for indexing
 

--- a/tests/integration/test_clients/test_workspace_edit_integration.py
+++ b/tests/integration/test_clients/test_workspace_edit_integration.py
@@ -32,6 +32,9 @@ class MockLSPClient(WithRespondApplyEdit):
         )
         self._config_map = ConfigurationMap({})
 
+    def get_document_state(self) -> DocumentStateManager:
+        return self.document_state
+
     async def read_file(self, file_path: AnyPath) -> str:
         if self._temp_dir:
             path = anyio.Path(file_path)


### PR DESCRIPTION
## Summary
- Fixed a bug in `request_rename` where the file was closed before the workspace edit was applied.
- Improved `WorkspaceEditApplicator` to handle untracked documents gracefully.
- Added comprehensive E2E tests for `BasedpyrightClient` rename functionality, including cross-file rename.
- Fixed `MockLSPClient` in integration tests to implement missing abstract method.