### PR TITLE
feat: add support for jdtls as default Java client

### DIFF
--- a/src/lsp_client/clients/__init__.py
+++ b/src/lsp_client/clients/__init__.py
@@ -5,6 +5,7 @@ from typing import Final
 from .basedpyright import BasedpyrightClient
 from .deno import DenoClient
 from .gopls import GoplsClient
+from .jdtls import JdtlsClient
 from .pyrefly import PyreflyClient
 from .pyright import PyrightClient
 from .rust_analyzer import RustAnalyzerClient
@@ -20,12 +21,14 @@ clients: Final = {
     "deno": DenoClient,
     "typescript": TypescriptClient,
     "ty": TyClient,
+    "jdtls": JdtlsClient,
 }
 
 __all__ = [
     "BasedpyrightClient",
     "DenoClient",
     "GoplsClient",
+    "JdtlsClient",
     "PyreflyClient",
     "PyrightClient",
     "RustAnalyzerClient",

--- a/src/lsp_client/clients/base.py
+++ b/src/lsp_client/clients/base.py
@@ -101,3 +101,32 @@ class TypeScriptClientBase(Client, ABC):
             suffixes=[".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"],
             project_files=["package.json", "tsconfig.json", "jsconfig.json"],
         )
+
+
+class JavaClientBase(Client, ABC):
+    """
+    Base class for Java language server clients.
+
+    Provides Java-specific configuration including file extensions (.java)
+    and common project configuration files (pom.xml, build.gradle, etc.).
+
+    Subclasses must implement:
+        create_default_servers(): Create server runtime instances
+        check_server_compatibility(): Verify server version compatibility
+    """
+
+    @override
+    @classmethod
+    def get_language_config(cls) -> LanguageConfig:
+        return LanguageConfig(
+            kind=lsp_type.LanguageKind.Java,
+            suffixes=[".java"],
+            project_files=[
+                "pom.xml",
+                "build.gradle",
+                "build.gradle.kts",
+                ".project",
+                "settings.gradle",
+                "settings.gradle.kts",
+            ],
+        )

--- a/src/lsp_client/clients/jdtls.py
+++ b/src/lsp_client/clients/jdtls.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import shutil
+from functools import partial
+from typing import Any, override
+
+from attrs import define
+from loguru import logger
+
+from lsp_client.capability.notification import WithNotifyDidChangeConfiguration
+from lsp_client.capability.request import (
+    WithRequestCallHierarchy,
+    WithRequestCodeAction,
+    WithRequestCompletion,
+    WithRequestDefinition,
+    WithRequestDocumentSymbol,
+    WithRequestHover,
+    WithRequestImplementation,
+    WithRequestInlayHint,
+    WithRequestReferences,
+    WithRequestRename,
+    WithRequestSignatureHelp,
+    WithRequestTypeDefinition,
+    WithRequestTypeHierarchy,
+    WithRequestWorkspaceSymbol,
+)
+from lsp_client.capability.server_notification import (
+    WithReceiveLogMessage,
+    WithReceiveLogTrace,
+    WithReceivePublishDiagnostics,
+    WithReceiveShowMessage,
+)
+from lsp_client.capability.server_request import (
+    WithRespondConfigurationRequest,
+    WithRespondInlayHintRefresh,
+    WithRespondShowDocumentRequest,
+    WithRespondShowMessageRequest,
+    WithRespondWorkspaceFoldersRequest,
+)
+from lsp_client.clients.base import JavaClientBase
+from lsp_client.server import DefaultServers, ServerInstallationError
+from lsp_client.server.container import ContainerServer
+from lsp_client.server.local import LocalServer
+from lsp_client.utils.types import lsp_type
+
+JdtlsContainerServer = partial(ContainerServer, image="ghcr.io/lsp-client/jdtls:latest")
+
+
+async def ensure_jdtls_installed() -> None:
+    if shutil.which("jdtls"):
+        return
+
+    logger.warning("jdtls not found in PATH.")
+    raise ServerInstallationError(
+        "jdtls not found. Please install Eclipse JDT Language Server (jdtls) and ensure it is in your PATH. "
+        "See https://github.com/eclipse/eclipse.jdt.ls for installation instructions."
+    )
+
+
+JdtlsLocalServer = partial(
+    LocalServer,
+    program="jdtls",
+    args=[],
+    ensure_installed=ensure_jdtls_installed,
+)
+
+
+@define
+class JdtlsClient(
+    JavaClientBase,
+    WithNotifyDidChangeConfiguration,
+    WithRequestCallHierarchy,
+    WithRequestCodeAction,
+    WithRequestCompletion,
+    WithRequestDefinition,
+    WithRequestDocumentSymbol,
+    WithRequestHover,
+    WithRequestImplementation,
+    WithRequestInlayHint,
+    WithRequestReferences,
+    WithRequestRename,
+    WithRequestSignatureHelp,
+    WithRequestTypeDefinition,
+    WithRequestTypeHierarchy,
+    WithRequestWorkspaceSymbol,
+    WithReceiveLogMessage,
+    WithReceiveLogTrace,
+    WithReceivePublishDiagnostics,
+    WithReceiveShowMessage,
+    WithRespondConfigurationRequest,
+    WithRespondInlayHintRefresh,
+    WithRespondShowDocumentRequest,
+    WithRespondShowMessageRequest,
+    WithRespondWorkspaceFoldersRequest,
+):
+    """
+    - Language: Java
+    - Homepage: https://github.com/eclipse/eclipse.jdt.ls
+    - Github: https://github.com/eclipse/eclipse.jdt.ls
+    - VSCode Extension: https://marketplace.visualstudio.com/items?itemName=redhat.java
+    """
+
+    @classmethod
+    @override
+    def create_default_servers(cls) -> DefaultServers:
+        return DefaultServers(
+            local=JdtlsLocalServer(),
+            container=JdtlsContainerServer(),
+        )
+
+    @override
+    def check_server_compatibility(self, info: lsp_type.ServerInfo | None) -> None:
+        return
+
+    @override
+    def create_default_config(self) -> dict[str, Any] | None:
+        """
+        https://github.com/redhat-developer/vscode-java/blob/master/package.json
+        """
+        return {
+            "java": {
+                "format": {
+                    "enabled": True,
+                },
+                "autobuild": {
+                    "enabled": True,
+                },
+                "completion": {
+                    "favoriteStaticMembers": [
+                        "org.junit.Assert.*",
+                        "org.junit.Assume.*",
+                        "org.junit.Juice.*",
+                        "org.junit.rules.ExpectedException.*",
+                        "org.hamcrest.MatcherAssert.*",
+                        "org.hamcrest.Matchers.*",
+                        "org.hamcrest.CoreMatchers.*",
+                        "java.util.Objects.*",
+                        "java.util.Arrays.*",
+                        "java.util.Collections.*",
+                    ],
+                    "importOrder": [
+                        "java",
+                        "javax",
+                        "com",
+                        "org",
+                    ],
+                },
+                "signatureHelp": {
+                    "enabled": True,
+                },
+                "contentProvider": {
+                    "preferred": "fernflower",
+                },
+            }
+        }

--- a/src/lsp_client/clients/jdtls.py
+++ b/src/lsp_client/clients/jdtls.py
@@ -129,7 +129,7 @@ class JdtlsClient(
                     "favoriteStaticMembers": [
                         "org.junit.Assert.*",
                         "org.junit.Assume.*",
-                        "org.junit.Juice.*",
+                        "org.junit.jupiter.*",
                         "org.junit.rules.ExpectedException.*",
                         "org.hamcrest.MatcherAssert.*",
                         "org.hamcrest.Matchers.*",

--- a/src/lsp_client/clients/lang.py
+++ b/src/lsp_client/clients/lang.py
@@ -9,6 +9,7 @@ from lsp_client.client.abc import Client
 from .basedpyright import BasedpyrightClient
 from .deno.client import DenoClient
 from .gopls import GoplsClient
+from .jdtls import JdtlsClient
 from .rust_analyzer import RustAnalyzerClient
 from .typescript import TypescriptClient
 
@@ -18,12 +19,14 @@ type Language = Literal[
     "rust",
     "typescript",
     "deno",
+    "java",
 ]
 
 GoClient = GoplsClient
 PythonClient = BasedpyrightClient
 RustClient = RustAnalyzerClient
 TypeScriptClient = TypescriptClient
+JavaClient = JdtlsClient
 
 lang_clients: Final[dict[Language, type[Client]]] = {
     "go": GoplsClient,
@@ -31,4 +34,5 @@ lang_clients: Final[dict[Language, type[Client]]] = {
     "rust": RustAnalyzerClient,
     "typescript": TypescriptClient,
     "deno": DenoClient,
+    "java": JdtlsClient,
 }

--- a/tests/unit/test_client/test_default_configuration.py
+++ b/tests/unit/test_client/test_default_configuration.py
@@ -154,3 +154,15 @@ def test_ty_default_config_has_diagnostics():
     assert config is not None
     assert "diagnostics" in config["ty"]
     assert "completion" in config["ty"]
+
+
+def test_jdtls_default_config_has_java_settings():
+    """Test that jdtls default config has java settings."""
+    from lsp_client.clients.jdtls import JdtlsClient
+
+    client = JdtlsClient()
+    config = client.create_default_config()
+
+    assert config is not None
+    assert "java" in config
+    assert config["java"]["autobuild"]["enabled"] is True


### PR DESCRIPTION
## Summary
- Added `JdtlsClient` for Java support using Eclipse JDT Language Server.
- Defined `JavaClientBase` with standard Java project patterns (Maven, Gradle).
- Configured default Java settings including autobuild and formatting.
- Integrated `jdtls` into the language client registry as the default for Java.