### PR TITLE
Fix lint and type errors using Python 3.12 features

### DIFF
--- a/examples/pyright_container.py
+++ b/examples/pyright_container.py
@@ -14,7 +14,7 @@ from lsp_client import Position
 from lsp_client.clients.pyright import PyrightClient, PyrightContainerServer
 
 
-async def main():
+async def main() -> None:
     # Set up workspace directory and mount it in Docker
     workspace = Path.cwd()
     async with PyrightClient(

--- a/examples/rename_preview.py
+++ b/examples/rename_preview.py
@@ -15,7 +15,7 @@ from lsprotocol.types import Position, SnippetTextEdit, TextDocumentEdit
 from lsp_client.clients import PyrightClient
 
 
-async def preview_rename_example():
+async def preview_rename_example() -> None:
     """Show how to preview rename changes before applying."""
     workspace = Path.cwd()
 
@@ -74,13 +74,13 @@ async def preview_rename_example():
             try:
                 await client.apply_workspace_edit(edits)
                 print("✓ Rename completed successfully")
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001
                 print(f"✗ Rename failed: {e}")
         else:
             print("Rename cancelled")
 
 
-async def direct_rename_example():
+async def direct_rename_example() -> None:
     """Show how to apply rename directly without preview."""
     workspace = Path.cwd()
 
@@ -101,7 +101,7 @@ async def direct_rename_example():
                 print("✓ Rename completed successfully")
             else:
                 print("✗ Rename not possible at this position")
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             print(f"✗ Rename failed: {e}")
 
 

--- a/examples/rust_analyzer.py
+++ b/examples/rust_analyzer.py
@@ -14,7 +14,7 @@ from lsp_client.clients.rust_analyzer import RustAnalyzerClient
 lsp_client.enable_logging()
 
 
-async def main():
+async def main() -> None:
     # Initialize Rust Analyzer client with local server
     async with RustAnalyzerClient() as client:
         # Get and display the language ID for this client

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,46 +40,6 @@ dev = [
 requires = ["uv_build>=0.9.9,<0.10.0"]
 build-backend = "uv_build"
 
-[tool.ruff]
-target-version = "py312"
-extend-exclude = ["references", "scripts/references"]
-
-[tool.ruff.format]
-quote-style = "double"
-indent-style = "space"
-
-# from https://github.com/astral-sh/ruff/blob/c1fed55d51b34e1235f72c610fe4b1700ed76451/pyproject.toml
-[tool.ruff.lint]
-select = [
-    "E",   # pycodestyle (error)
-    "F",   # pyflakes
-    "B",   # bugbear
-    "B9",
-    "C4",  # flake8-comprehensions
-    "SIM", # flake8-simplify
-    "I",   # isort
-    "UP",  # pyupgrade
-    "PIE", # flake8-pie
-    "PGH", # pygrep-hooks
-    "PYI", # flake8-pyi
-    "RUF",
-]
-
-ignore = [
-    # only relevant if you run a script with `python -0`,
-    # which seems unlikely for any of the scripts in this repo
-    "B011",
-    # Leave it to the formatter to split long lines and
-    # the judgement of all of us.
-    "E501",
-]
-
-[tool.ruff.lint.isort]
-required-imports = ["from __future__ import annotations"]
-
-[tool.ruff.lint.per-file-ignores]
-"tests/fixtures/**/*.py" = ["F821"]
-
 [tool.pytest.ini_options]
 # Register custom markers
 markers = [

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,50 @@
+target-version = "py312"
+line-length = 88
+extend-exclude = ["references", "scripts/references"]
+
+[lint]
+select = [
+    "E", "W",          # Basic pycodestyle styling (non-disruptive)
+    "F",               # Pyflakes — actual logic errors (must-have)
+    "I",               # isort — consistent import ordering
+    "B", "B9",         # flake8-bugbear — common mistakes and gotchas
+    "UP",              # pyupgrade — modern syntax where possible
+    "SIM",             # flake8-simplify — simpler logic constructs
+    "PIE",             # flake8-pie — code improvements
+    "C4",              # flake8-comprehensions — better comprehensions
+    "RET",             # flake8-return — consistent return statements
+    "BLE",             # blind except — avoid 'except:' without type
+    "TRY",             # tryceratops — clean exception handling
+    "RSE",             # raise — ensure proper raise statements
+    "ANN",             # flake8-annotations — enforce type hints
+    "PGH",             # pygrep-hooks — PGH003: no blanket type: ignore
+    "PTH",             # pathlib — prefer pathlib over os.path
+    "PERF",            # perflint — performance anti-patterns
+    "PYI",             # flake8-pyi
+    "RUF",             # Ruff-specific rules
+]
+
+ignore = [
+    "B011",    # only relevant if you run a script with `python -O`
+    "E501",    # Line length (handled by formatter)
+    "COM812",  # Trailing comma (conflicts with formatter)
+    "ISC001",  # Implicit string concatenation (conflicts with formatter)
+    "PLR0913", # Too many arguments - sometimes necessary
+    "PLR2004", # Magic value comparison - sometimes reasonable
+    "TRY003",  # Long exception message - custom error messages are common
+    "ANN401",  # Dynamically typed expressions (typing.Any) are disallowed
+]
+
+[lint.isort]
+required-imports = ["from __future__ import annotations"]
+known-first-party = ["lsp_client"]
+
+[lint.per-file-ignores]
+"tests/fixtures/**/*.py" = ["F821"]
+"tests/**/*.py" = [
+    "ANN", "SIM", "PIE", "C4", "RET", "BLE", "TRY", "RSE", "PERF",
+]
+
+[format]
+quote-style = "double"
+indent-style = "space"

--- a/src/lsp_client/capability/diagnostic/document.py
+++ b/src/lsp_client/capability/diagnostic/document.py
@@ -106,3 +106,4 @@ class WithDocumentDiagnostic(
                     "Unsupported diagnostic report type for file {}",
                     file_path,
                 )
+        return None

--- a/src/lsp_client/capability/request/call_hierarchy.py
+++ b/src/lsp_client/capability/request/call_hierarchy.py
@@ -128,6 +128,7 @@ class WithRequestCallHierarchy(
 
             if calls:
                 return calls
+        return None
 
     async def request_call_hierarchy_outgoing_call(
         self, file_path: AnyPath, position: Position
@@ -164,3 +165,4 @@ class WithRequestCallHierarchy(
 
             if calls:
                 return calls
+        return None

--- a/src/lsp_client/capability/request/document_symbol.py
+++ b/src/lsp_client/capability/request/document_symbol.py
@@ -90,6 +90,7 @@ class WithRequestDocumentSymbol(
                 logger.warning(
                     "Document symbol returned with unexpected result: {}", other
                 )
+        return None
 
     async def request_document_symbol_list(
         self, file_path: AnyPath

--- a/src/lsp_client/capability/request/type_hierarchy.py
+++ b/src/lsp_client/capability/request/type_hierarchy.py
@@ -120,6 +120,7 @@ class WithRequestTypeHierarchy(
 
             if items:
                 return items
+        return None
 
     async def request_type_hierarchy_subtypes(
         self, file_path: AnyPath, position: Position
@@ -151,3 +152,4 @@ class WithRequestTypeHierarchy(
 
             if items:
                 return items
+        return None

--- a/src/lsp_client/capability/server_request/configuration.py
+++ b/src/lsp_client/capability/server_request/configuration.py
@@ -60,7 +60,7 @@ class WithRespondConfigurationRequest(
         """
 
         if not (config := self.get_config_map()):
-            return
+            return None
         return config.get(scope_uri, section)
 
     async def _respond_configuration(

--- a/src/lsp_client/client/abc.py
+++ b/src/lsp_client/client/abc.py
@@ -305,7 +305,7 @@ class Client(
             lsp_type.InitializedNotification(params=lsp_type.InitializedParams())
         )
 
-    async def _shutdown(self):
+    async def _shutdown(self) -> None:
         """
         `shutdown` - https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#shutdown
         """

--- a/src/lsp_client/client/buffer.py
+++ b/src/lsp_client/client/buffer.py
@@ -82,7 +82,7 @@ class LSPFileBuffer:
 
         items: list[LSPFileBufferItem] = []
 
-        async def append_item(uri: str):
+        async def append_item(uri: str) -> None:
             text = await anyio.Path(from_local_uri(uri)).read_bytes()
             items.append(LSPFileBufferItem(file_uri=uri, file_content=text))
 

--- a/src/lsp_client/client/exception.py
+++ b/src/lsp_client/client/exception.py
@@ -15,6 +15,6 @@ class ClientError(LSPError):
 class ClientRuntimeError(ClientError):
     """Raised when a client encounters a runtime error."""
 
-    def __init__(self, client: Client, *args: object):
+    def __init__(self, client: Client, *args: object) -> None:
         super().__init__(*args)
         self.client = client

--- a/src/lsp_client/clients/basedpyright.py
+++ b/src/lsp_client/clients/basedpyright.py
@@ -72,9 +72,10 @@ async def ensure_basedpyright_installed() -> None:
             try:
                 logger.info("Attempting to install basedpyright via {}...", name)
                 await anyio.run_process(cmd)
-                return
             except CalledProcessError:
                 continue
+            else:
+                return
 
     raise ServerInstallationError(
         "Could not install basedpyright. Please install it manually with 'uv tool install basedpyright', 'npm install -g basedpyright' or 'pip install basedpyright'."

--- a/src/lsp_client/clients/deno/client.py
+++ b/src/lsp_client/clients/deno/client.py
@@ -76,13 +76,14 @@ async def ensure_deno_installed() -> None:
             ["sh", "-c", "curl -fsSL https://deno.land/install.sh | sh"]
         )
         logger.info("Successfully installed deno via shell script")
-        return
     except CalledProcessError as e:
         raise ServerInstallationError(
             "Could not install deno. Please install it manually with:\n"
             "curl -fsSL https://deno.land/install.sh | sh\n\n"
             "See https://deno.land/ for more information."
         ) from e
+    else:
+        return
 
 
 DenoLocalServer = partial(

--- a/src/lsp_client/clients/gopls.py
+++ b/src/lsp_client/clients/gopls.py
@@ -56,12 +56,13 @@ async def ensure_gopls_installed() -> None:
     try:
         await anyio.run_process(["go", "install", "golang.org/x/tools/gopls@latest"])
         logger.info("Successfully installed gopls via go install")
-        return
     except CalledProcessError as e:
         raise ServerInstallationError(
             "Could not install gopls. Please install it manually with 'go install golang.org/x/tools/gopls@latest'. "
             "See https://github.com/golang/tools/tree/master/gopls for more information."
         ) from e
+    else:
+        return
 
 
 GoplsLocalServer = partial(

--- a/src/lsp_client/clients/pyright.py
+++ b/src/lsp_client/clients/pyright.py
@@ -65,12 +65,13 @@ async def ensure_pyright_installed() -> None:
     try:
         await anyio.run_process(["npm", "install", "-g", "pyright"])
         logger.info("Successfully installed pyright-langserver via npm")
-        return
     except CalledProcessError as e:
         raise ServerInstallationError(
             "Could not install pyright-langserver. Please install it manually with 'npm install -g pyright'. "
             "See https://microsoft.github.io/pyright/ for more information."
         ) from e
+    else:
+        return
 
 
 PyrightLocalServer = partial(

--- a/src/lsp_client/clients/ty.py
+++ b/src/lsp_client/clients/ty.py
@@ -59,12 +59,13 @@ async def ensure_ty_installed() -> None:
     try:
         await anyio.run_process([sys.executable, "-m", "pip", "install", "ty"])
         logger.info("Successfully installed ty via pip")
-        return
     except CalledProcessError as e:
         raise ServerInstallationError(
             "Could not install ty. Please install it manually with 'pip install ty' or 'uv tool install ty'. "
             "See https://docs.astral.sh/ty/installation/ for more information."
         ) from e
+    else:
+        return
 
 
 TyLocalServer = partial(

--- a/src/lsp_client/clients/typescript.py
+++ b/src/lsp_client/clients/typescript.py
@@ -64,12 +64,13 @@ async def ensure_typescript_installed() -> None:
             ["npm", "install", "-g", "typescript-language-server", "typescript"]
         )
         logger.info("Successfully installed typescript-language-server via npm")
-        return
     except CalledProcessError as e:
         raise ServerInstallationError(
             "Could not install typescript-language-server and typescript. Please install them manually with 'npm install -g typescript-language-server typescript'. "
             "See https://github.com/typescript-language-server/typescript-language-server for more information."
         ) from e
+    else:
+        return
 
 
 TypescriptLocalServer = partial(

--- a/src/lsp_client/jsonrpc/convert.py
+++ b/src/lsp_client/jsonrpc/convert.py
@@ -33,14 +33,13 @@ def _(
 
     if object_ is None:
         return None
-    elif isinstance(object_, str):
+    if isinstance(object_, str):
         return str(object_)
-    elif "notebookType" in object_:
+    if "notebookType" in object_:
         return converter.structure(object_, lsp_type.NotebookDocumentFilterNotebookType)
-    elif "scheme" in object_:
+    if "scheme" in object_:
         return converter.structure(object_, lsp_type.NotebookDocumentFilterScheme)
-    else:
-        return converter.structure(object_, lsp_type.NotebookDocumentFilterPattern)
+    return converter.structure(object_, lsp_type.NotebookDocumentFilterPattern)
 
 
 def value_deserialize[R](raw_value: Any, schema: type[R]) -> R:
@@ -77,8 +76,7 @@ def response_deserialize[R](
             err_resp = converter.structure(raw_err_resp, lsp_type.ResponseErrorMessage)
             if err := err_resp.error:
                 raise JsonRpcResponseError(err.code, err.message, err.data)
-            else:
-                raise JsonRpcParseError(f"Invalid Error Response: {err_resp}")
+            raise JsonRpcParseError(f"Invalid Error Response: {err_resp}")
         case {"result": _} as raw_resp:
             resp = converter.structure(raw_resp, schema)
             return resp.result

--- a/src/lsp_client/jsonrpc/exception.py
+++ b/src/lsp_client/jsonrpc/exception.py
@@ -18,7 +18,7 @@ class JsonRpcTransportError(JsonRpcError):
 class JsonRpcResponseError(JsonRpcError):
     """Raised when the JSON-RPC response indicates an error."""
 
-    def __init__(self, code: int, message: str, data: object = None):
+    def __init__(self, code: int, message: str, data: object = None) -> None:
         super().__init__(f"JSON-RPC Error {code}: {message}")
         self.code = code
         self.message = message

--- a/src/lsp_client/protocol/client.py
+++ b/src/lsp_client/protocol/client.py
@@ -100,11 +100,11 @@ class CapabilityClientProtocol(DocumentEditProtocol, Protocol):
         if len(self.get_workspace()) == 1:  # single root workspace
             folder = self.get_workspace()[DEFAULT_WORKSPACE_DIR]
             return (folder.path / file_path).as_uri()
-        else:  # multi-root workspace
-            if (root := file_path.parts[0]) not in self.get_workspace():
-                raise ValueError(f"{root} is not a valid workspace folder")
-            folder = self.get_workspace()[root]
-            return (folder.path / Path(*file_path.parts[1:])).as_uri()
+        # multi-root workspace
+        if (root := file_path.parts[0]) not in self.get_workspace():
+            raise ValueError(f"{root} is not a valid workspace folder")
+        folder = self.get_workspace()[root]
+        return (folder.path / Path(*file_path.parts[1:])).as_uri()
 
     def from_uri(self, uri: str, *, relative: bool = True) -> Path:
         """

--- a/src/lsp_client/protocol/lang.py
+++ b/src/lsp_client/protocol/lang.py
@@ -32,14 +32,15 @@ class LanguageConfig:
     def _find_project_root(self, dir_path: Path) -> Path | None:
         for project_path in (dir_path, *dir_path.parents):
             if any((project_path / excl).exists() for excl in self.exclude_files):
-                return
+                return None
             if any((project_path / proj).exists() for proj in self.project_files):
                 return project_path
+        return None
 
     def find_project_root(self, path: Path) -> Path | None:
         if path.is_file():
             if not any(path.name.endswith(suffix) for suffix in self.suffixes):
-                return
+                return None
             path = path.parent
 
         return self._find_project_root(path)

--- a/src/lsp_client/server/abc.py
+++ b/src/lsp_client/server/abc.py
@@ -152,10 +152,11 @@ class StreamServer(Server):
         try:
             package = await read_raw_package(self._buffered_receive_stream)
             logger.debug("Received package: {}", package)
-            return package
         except (anyio.EndOfStream, anyio.IncompleteRead, anyio.ClosedResourceError):
             logger.debug("Stream closed")
             return None
+        else:
+            return package
 
     async def _handle_package(
         self, sender: Sender[ServerRequest], package: RawPackage

--- a/src/lsp_client/server/error.py
+++ b/src/lsp_client/server/error.py
@@ -15,7 +15,7 @@ class ServerError(LSPError):
 class ServerRuntimeError(ServerError):
     """Raised when a server fails to start or crashes during execution."""
 
-    def __init__(self, server: Server, *args: object):
+    def __init__(self, server: Server, *args: object) -> None:
         super().__init__(*args)
         self.server = server
 

--- a/src/lsp_client/utils/warn.py
+++ b/src/lsp_client/utils/warn.py
@@ -2,14 +2,16 @@ from __future__ import annotations
 
 import functools
 import warnings
+from collections.abc import Callable
 
 
-def deprecated(reason: str):
-    def decorator(func):
+def deprecated[**P, R](reason: str) -> Callable[[Callable[P, R]], Callable[P, R]]:
+    def decorator(func: Callable[P, R]) -> Callable[P, R]:
         @functools.wraps(func)
-        def wrapper(*args, **kwargs):
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+            name = getattr(func, "__name__", "function")
             warnings.warn(
-                f"{func.__name__} deprecated: {reason}",
+                f"{name} deprecated: {reason}",
                 DeprecationWarning,
                 stacklevel=2,
             )

--- a/src/lsp_client/utils/workspace_edit.py
+++ b/src/lsp_client/utils/workspace_edit.py
@@ -316,12 +316,11 @@ class WorkspaceEditApplicator:
                     f"Skipping DeleteFile for {uri}: file does not exist and ignoreIfNotExists is true"
                 )
                 return
-            else:
-                # Default behavior: fail if file doesn't exist
-                raise EditApplicationError(
-                    message=f"File {uri} does not exist",
-                    uri=uri,
-                )
+            # Default behavior: fail if file doesn't exist
+            raise EditApplicationError(
+                message=f"File {uri} does not exist",
+                uri=uri,
+            )
 
         # Handle directory or file
         if await path.is_dir():


### PR DESCRIPTION
## Summary
This PR addresses multiple lint and type errors across the codebase, leveraging Python 3.12 features:

- **Type Safety in Decorators**: Re-implemented the `@deprecated` decorator using Python 3.12 PEP 695 generic syntax (`[**P, R]`). This ensures that the decorator preserves the original function's signature and return type while being fully type-safe.
- **Lint Fixes (TRY300)**: Moved return statements out of `try` blocks into `else` blocks in several server installation and communication routines, as recommended by Ruff.
- **Type Annotations**: Added missing return and argument type annotations in `warn.py` and other utility functions.
- **Example Improvements**: Added `noqa: BLE001` to example files where catching generic `Exception` is intentional for demonstration purposes.

These changes ensure the codebase remains compliant with strict type checking and the latest Python coding standards.