### PR TITLE
feat: enhance Code Action support

### DIFF
--- a/src/lsp_client/capability/request/code_action.py
+++ b/src/lsp_client/capability/request/code_action.py
@@ -109,3 +109,21 @@ class WithRequestCodeAction(
         code_action: lsp_type.CodeAction,
     ) -> lsp_type.CodeAction:
         return await self._request_code_action_resolve(code_action)
+
+    def get_supported_code_action_kinds(
+        self,
+    ) -> Sequence[lsp_type.CodeActionKind | str] | None:
+        """
+        Get the code action kinds supported by the server.
+
+        Returns:
+            A sequence of supported code action kinds, or None if the server
+            doesn't specify them or doesn't support code actions.
+        """
+
+        cap = self.get_server_capabilities()
+        match cap.code_action_provider:
+            case lsp_type.CodeActionOptions(code_action_kinds=kinds):
+                return kinds
+            case _:
+                return None

--- a/src/lsp_client/client/abc.py
+++ b/src/lsp_client/client/abc.py
@@ -90,6 +90,7 @@ class Client(
     initialization_options: dict[str, Any] = field(factory=dict)
     """Custom initialization options for the server."""
 
+    _server_capabilities: lsp_type.ServerCapabilities = field(init=False)
     _server: Server = field(init=False)
     _buffer: LSPFileBuffer = field(factory=LSPFileBuffer, init=False)
     document_state: DocumentStateManager = field(
@@ -159,6 +160,10 @@ class Client(
     @override
     def get_config_map(self) -> ConfigurationMap:
         return self._config
+
+    @override
+    def get_server_capabilities(self) -> lsp_type.ServerCapabilities:
+        return self._server_capabilities
 
     def get_server(self) -> Server:
         return self._server
@@ -288,7 +293,7 @@ class Client(
             lsp_type.InitializeRequest(id="initialize", params=params),
             schema=lsp_type.InitializeResponse,
         )
-        server_capabilities = result.capabilities
+        self._server_capabilities = result.capabilities
         server_info = result.server_info
 
         if __debug__:
@@ -297,7 +302,7 @@ class Client(
 
             # ensure all client capabilities are supported by the server
             if isinstance(self, CapabilityProtocol):
-                self.check_server_capability(server_capabilities)
+                self.check_server_capability(self._server_capabilities)
         else:
             logger.debug("Skip server check in optimized mode")
 

--- a/src/lsp_client/protocol/client.py
+++ b/src/lsp_client/protocol/client.py
@@ -7,7 +7,7 @@ workspace management, configuration access, file operations, and LSP message han
 from __future__ import annotations
 
 from abc import abstractmethod
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Protocol, runtime_checkable
@@ -16,7 +16,7 @@ import anyio
 
 from lsp_client.client.document_state import DocumentStateManager
 from lsp_client.utils.config import ConfigurationMap
-from lsp_client.utils.types import AnyPath, Notification, Request, Response
+from lsp_client.utils.types import AnyPath, Notification, Request, Response, lsp_type
 from lsp_client.utils.uri import from_local_uri
 from lsp_client.utils.workspace import DEFAULT_WORKSPACE_DIR, Workspace
 
@@ -64,8 +64,12 @@ class CapabilityClientProtocol(DocumentEditProtocol, Protocol):
         """Get language-specific configuration for this client."""
 
     @abstractmethod
+    def get_server_capabilities(self) -> lsp_type.ServerCapabilities:
+        """Get the capabilities of the language server."""
+
+    @abstractmethod
     @asynccontextmanager
-    def open_files(self, *file_paths: AnyPath) -> AsyncGenerator[None]:
+    def open_files(self, *file_paths: AnyPath) -> AsyncIterator[None]:
         """Open files in the client.
 
         Args:


### PR DESCRIPTION
## Summary
- Add get_supported_code_action_kinds() method to query server's supported code action kinds
- Cache server capabilities in Client for efficient access
- Update type annotations for better compatibility

## Changes
- src/lsp_client/capability/request/code_action.py: Add method to get supported code action kinds
- src/lsp_client/client/abc.py: Add server capabilities caching
- src/lsp_client/protocol/client.py: Add abstract method for server capabilities