### PR TITLE
feat: mount workspace as readonly for security

### DIFF
--- a/src/lsp_client/server/container.py
+++ b/src/lsp_client/server/container.py
@@ -186,6 +186,7 @@ class ContainerServer(StreamServer):
                 mount = BindMount(
                     source=str(folder.path),
                     target=self.workdir.as_posix(),
+                    readonly=True,
                 )
                 mounts.append(mount)
             case folders:
@@ -193,6 +194,7 @@ class ContainerServer(StreamServer):
                     BindMount(
                         source=str(folder.path),
                         target=(self.workdir / folder.name).as_posix(),
+                        readonly=True,
                     )
                     for folder in folders
                 )


### PR DESCRIPTION
## Summary

- Mount workspace directories as readonly by default in container runtime
- This prevents accidental modifications from within containers running as root

## Context

Container images now run as root by default. Mounting the workspace directory as readonly provides an additional layer of security to prevent containerized processes from modifying the host filesystem.