### PR TITLE
fix: map container paths to host paths to fix URI resolution

### DIFF
--- a/tests/unit/test_server/test_abc.py
+++ b/tests/unit/test_server/test_abc.py
@@ -52,14 +52,12 @@ class TestContainerServer:
         server = ContainerServer(image="test-image")
         assert server.image == "test-image"
 
-    def test_container_server_default_workdir(self):
-        """Test that ContainerServer has default workdir."""
-        from pathlib import Path
-
+    def test_container_server_no_workdir(self):
+        """Test that ContainerServer no longer has workdir attribute."""
         from lsp_client.server.container import ContainerServer
 
         server = ContainerServer(image="test-image")
-        assert server.workdir == Path("/workspace")
+        assert not hasattr(server, "workdir")
 
     def test_container_server_default_backend(self):
         """Test that ContainerServer has default backend."""


### PR DESCRIPTION
## Summary
- Modified `BindMount.from_path` to support explicit target paths.
- Updated `ContainerServer.format_args` to mount workspace folders at their host POSIX paths.
- Removed `workdir` from `ContainerServer` as it's no longer needed when using host-consistent paths.
- This fixes issues where LSP servers in containers could not correctly resolve file URIs due to path mismatches between host and container.