### PR TITLE
feat: add container reuse support with auto-remove option

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "pydantic-settings>=2.12.0",
     "semver>=3.0.4",
     "tenacity>=9.1.2",
+    "xxhash>=3.6.0",
 ]
 
 [dependency-groups]

--- a/src/lsp_client/server/container.py
+++ b/src/lsp_client/server/container.py
@@ -169,21 +169,102 @@ class ContainerServer(StreamServer):
         await self._local.kill()
 
     def _generate_hash_name(self, workspace: Workspace) -> str:
-        seed = f"{self.image}:{workspace.id}"
-        path_hash = xxhash.xxh32_hexdigest(seed.encode(), seed=0)
+        """Generate a deterministic container name for a workspace.
+
+        The name is derived from the container image and the workspace ID so
+        that the same workspace gets the same container name across sessions,
+        enabling container reuse when auto_remove is disabled.
+        """
+        hash_input = f"{self.image}:{workspace.id}"
+        path_hash = xxhash.xxh32_hexdigest(hash_input.encode(), seed=0)
         return f"lsp-server-{path_hash}"
 
     async def _container_exists(self, name: str) -> bool:
+        """
+        Return True only if a container with the given name exists and is in a state
+        suitable for reuse (i.e. can be started with `start -ai`).
+        """
         try:
-            await anyio.run_process(
-                [self.backend, "inspect", name],
-                stdout=subprocess.DEVNULL,
+            # Query the container's state; Docker/Podman expose it via .State.Status
+            result = await anyio.run_process(
+                [self.backend, "inspect", "--format={{.State.Status}}", name],
+                stdout=subprocess.PIPE,
                 stderr=subprocess.DEVNULL,
             )
         except (anyio.ProcessError, FileNotFoundError):
+            # Container does not exist or backend is unavailable.
             return False
-        else:
+
+        state = (result.stdout or b"").decode().strip().lower()
+        if state in ("exited", "created"):
             return True
+
+        logger.debug(
+            "Container '{}' exists but is in state '{}' which is not suitable for reuse",
+            name,
+            state or "<unknown>",
+        )
+        return False
+
+    async def _get_container_mounts(self, name: str) -> list[str]:
+        """
+        Get the list of mount targets from an existing container.
+
+        Returns a list of target paths that are mounted in the container.
+        """
+        try:
+            result = await anyio.run_process(
+                [
+                    self.backend,
+                    "inspect",
+                    "--format={{range .Mounts}}{{.Destination}}\n{{end}}",
+                    name,
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+            )
+        except (anyio.ProcessError, FileNotFoundError):
+            return []
+
+        output = (result.stdout or b"").decode().strip()
+        if not output:
+            return []
+
+        return [line.strip() for line in output.split("\n") if line.strip()]
+
+    def _get_expected_mount_targets(self, workspace: Workspace) -> set[str]:
+        """
+        Get the set of expected mount targets for the current workspace.
+
+        Returns a set of target paths that should be mounted.
+        """
+        mounts = list(self.mounts)
+        folders = workspace.to_folders()
+
+        mounts.extend(
+            BindMount.from_path(
+                folder.path, readonly=True, target=folder.path.as_posix()
+            )
+            for folder in folders
+        )
+
+        targets = set()
+        for mount in mounts:
+            if isinstance(mount, Path):
+                mount_obj = BindMount.from_path(mount)
+                targets.add(mount_obj.target)
+            elif isinstance(mount, str):
+                # Parse mount string to extract target
+                # Format: type=...,source=...,target=...,readonly
+                parts = mount.split(",")
+                for part in parts:
+                    if part.startswith("target="):
+                        targets.add(part.split("=", 1)[1])
+                        break
+            else:
+                targets.add(mount.target)
+
+        return targets
 
     @override
     async def check_availability(self) -> None:
@@ -236,11 +317,34 @@ class ContainerServer(StreamServer):
         if not self.auto_remove:
             name = self.container_name or self._generate_hash_name(workspace)
             if await self._container_exists(name):
-                logger.debug("Reusing existing container: {}", name)
-                self._local = LocalServer(
-                    program=self.backend, args=["start", "-ai", name]
+                # Validate that the existing container has the correct mounts
+                existing_mounts = set(await self._get_container_mounts(name))
+                expected_mounts = self._get_expected_mount_targets(workspace)
+
+                if existing_mounts == expected_mounts:
+                    logger.debug("Reusing existing container: {}", name)
+                    self._local = LocalServer(
+                        program=self.backend, args=["start", "-ai", name]
+                    )
+                    return
+                logger.debug(
+                    "Container '{}' exists but has incorrect mounts. "
+                    "Expected: {}, Got: {}. Removing and recreating.",
+                    name,
+                    expected_mounts,
+                    existing_mounts,
                 )
-                return
+                # Remove the container with incorrect mounts
+                try:
+                    await anyio.run_process(
+                        [self.backend, "rm", "-f", name],
+                        stdout=subprocess.DEVNULL,
+                        stderr=subprocess.DEVNULL,
+                    )
+                except (anyio.ProcessError, FileNotFoundError):
+                    logger.warning(
+                        "Failed to remove container '{}' with incorrect mounts", name
+                    )
 
         args = self.format_args(workspace)
         logger.debug("Running container runtime with command: {}", args)

--- a/src/lsp_client/utils/workspace.py
+++ b/src/lsp_client/utils/workspace.py
@@ -56,9 +56,16 @@ class Workspace(dict[str, WorkspaceFolder]):
 
     @cached_property
     def id(self) -> str:
+        """
+        Return a deterministic hash-based identifier for the workspace.
+
+        The identifier is computed by hashing the sorted workspace folder
+        names and their URIs, ensuring a stable value for the same set
+        of folders regardless of insertion order.
+        """
         items = sorted(self.items())
         return xxhash.xxh32_hexdigest(
-            "|".join(f"{name}:{folder.uri}" for name, folder in items)
+            "|".join(f"{name}:{folder.uri}" for name, folder in items).encode()
         )
 
 

--- a/src/lsp_client/utils/workspace.py
+++ b/src/lsp_client/utils/workspace.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Final
 
 import attrs
+import xxhash
 
 from .types import AnyPath, lsp_type
 from .uri import from_local_uri
@@ -52,6 +53,13 @@ class Workspace(dict[str, WorkspaceFolder]):
 
     def to_folders(self) -> list[WorkspaceFolder]:
         return list(self.values())
+
+    @cached_property
+    def id(self) -> str:
+        items = sorted(self.items())
+        return xxhash.xxh32_hexdigest(
+            "|".join(f"{name}:{folder.uri}" for name, folder in items)
+        )
 
 
 DEFAULT_WORKSPACE_PATH = Path.cwd()

--- a/tests/unit/test_server/test_container_reuse.py
+++ b/tests/unit/test_server/test_container_reuse.py
@@ -1,0 +1,275 @@
+from __future__ import annotations
+
+"""
+Unit tests for ContainerServer container reuse functionality.
+
+Tests cover auto_remove flag, hash-based naming, container existence checking,
+and mount validation.
+"""
+
+import pytest
+
+from lsp_client.server.container import ContainerServer
+from lsp_client.utils.workspace import Workspace, WorkspaceFolder
+
+
+class TestContainerServerAutoRemove:
+    """Tests for auto_remove flag functionality."""
+
+    def test_auto_remove_default_true(self):
+        """Test that auto_remove defaults to True."""
+        server = ContainerServer(image="test-image")
+        assert server.auto_remove is True
+
+    def test_auto_remove_can_be_set_false(self):
+        """Test that auto_remove can be set to False."""
+        server = ContainerServer(image="test-image", auto_remove=False)
+        assert server.auto_remove is False
+
+    def test_format_args_includes_rm_when_auto_remove_true(self):
+        """Test that --rm flag is included when auto_remove is True."""
+        server = ContainerServer(image="test-image", auto_remove=True)
+        workspace = Workspace(
+            {
+                "root": WorkspaceFolder(
+                    uri="file:///test/path",
+                    name="root",
+                )
+            }
+        )
+        args = server.format_args(workspace)
+        assert "--rm" in args
+
+    def test_format_args_excludes_rm_when_auto_remove_false(self):
+        """Test that --rm flag is excluded when auto_remove is False."""
+        server = ContainerServer(image="test-image", auto_remove=False)
+        workspace = Workspace(
+            {
+                "root": WorkspaceFolder(
+                    uri="file:///test/path",
+                    name="root",
+                )
+            }
+        )
+        args = server.format_args(workspace)
+        assert "--rm" not in args
+
+
+class TestContainerServerHashNaming:
+    """Tests for hash-based container naming."""
+
+    def test_generate_hash_name_is_deterministic(self):
+        """Test that hash name generation is deterministic."""
+        server = ContainerServer(image="test-image")
+        workspace = Workspace(
+            {
+                "root": WorkspaceFolder(
+                    uri="file:///test/path",
+                    name="root",
+                )
+            }
+        )
+
+        name1 = server._generate_hash_name(workspace)
+        name2 = server._generate_hash_name(workspace)
+
+        assert name1 == name2
+        assert name1.startswith("lsp-server-")
+
+    def test_generate_hash_name_differs_for_different_workspaces(self):
+        """Test that different workspaces get different hash names."""
+        server = ContainerServer(image="test-image")
+        workspace1 = Workspace(
+            {
+                "root": WorkspaceFolder(
+                    uri="file:///test/path1",
+                    name="root",
+                )
+            }
+        )
+        workspace2 = Workspace(
+            {
+                "root": WorkspaceFolder(
+                    uri="file:///test/path2",
+                    name="root",
+                )
+            }
+        )
+
+        name1 = server._generate_hash_name(workspace1)
+        name2 = server._generate_hash_name(workspace2)
+
+        assert name1 != name2
+
+    def test_generate_hash_name_differs_for_different_images(self):
+        """Test that different images get different hash names."""
+        server1 = ContainerServer(image="test-image-1")
+        server2 = ContainerServer(image="test-image-2")
+        workspace = Workspace(
+            {
+                "root": WorkspaceFolder(
+                    uri="file:///test/path",
+                    name="root",
+                )
+            }
+        )
+
+        name1 = server1._generate_hash_name(workspace)
+        name2 = server2._generate_hash_name(workspace)
+
+        assert name1 != name2
+
+    def test_format_args_uses_hash_name_when_auto_remove_false(self):
+        """Test that hash-based name is used when auto_remove is False."""
+        server = ContainerServer(image="test-image", auto_remove=False)
+        workspace = Workspace(
+            {
+                "root": WorkspaceFolder(
+                    uri="file:///test/path",
+                    name="root",
+                )
+            }
+        )
+
+        args = server.format_args(workspace)
+        expected_name = server._generate_hash_name(workspace)
+
+        assert "--name" in args
+        name_index = args.index("--name")
+        assert args[name_index + 1] == expected_name
+
+    def test_format_args_prefers_custom_name_over_hash(self):
+        """Test that custom container_name takes precedence over hash."""
+        server = ContainerServer(
+            image="test-image", auto_remove=False, container_name="my-custom-name"
+        )
+        workspace = Workspace(
+            {
+                "root": WorkspaceFolder(
+                    uri="file:///test/path",
+                    name="root",
+                )
+            }
+        )
+
+        args = server.format_args(workspace)
+
+        assert "--name" in args
+        name_index = args.index("--name")
+        assert args[name_index + 1] == "my-custom-name"
+
+
+class TestWorkspaceId:
+    """Tests for workspace ID generation."""
+
+    def test_workspace_id_is_deterministic(self):
+        """Test that workspace ID is deterministic."""
+        workspace = Workspace(
+            {
+                "root": WorkspaceFolder(
+                    uri="file:///test/path",
+                    name="root",
+                )
+            }
+        )
+
+        id1 = workspace.id
+        id2 = workspace.id
+
+        assert id1 == id2
+        assert isinstance(id1, str)
+        assert len(id1) > 0
+
+    def test_workspace_id_differs_for_different_workspaces(self):
+        """Test that different workspaces have different IDs."""
+        workspace1 = Workspace(
+            {
+                "root": WorkspaceFolder(
+                    uri="file:///test/path1",
+                    name="root",
+                )
+            }
+        )
+        workspace2 = Workspace(
+            {
+                "root": WorkspaceFolder(
+                    uri="file:///test/path2",
+                    name="root",
+                )
+            }
+        )
+
+        assert workspace1.id != workspace2.id
+
+    def test_workspace_id_same_for_same_folders_different_order(self):
+        """Test that workspace ID is consistent regardless of folder order."""
+        workspace1 = Workspace(
+            {
+                "folder1": WorkspaceFolder(
+                    uri="file:///test/path1",
+                    name="folder1",
+                ),
+                "folder2": WorkspaceFolder(
+                    uri="file:///test/path2",
+                    name="folder2",
+                ),
+            }
+        )
+        workspace2 = Workspace(
+            {
+                "folder2": WorkspaceFolder(
+                    uri="file:///test/path2",
+                    name="folder2",
+                ),
+                "folder1": WorkspaceFolder(
+                    uri="file:///test/path1",
+                    name="folder1",
+                ),
+            }
+        )
+
+        # Should be the same because items are sorted before hashing
+        assert workspace1.id == workspace2.id
+
+
+class TestContainerServerMountTargets:
+    """Tests for getting expected mount targets."""
+
+    def test_get_expected_mount_targets_for_workspace_folders(self):
+        """Test that workspace folders are included in expected mount targets."""
+        server = ContainerServer(image="test-image")
+        workspace = Workspace(
+            {
+                "root": WorkspaceFolder(
+                    uri="file:///test/path",
+                    name="root",
+                )
+            }
+        )
+
+        targets = server._get_expected_mount_targets(workspace)
+
+        # Should include the workspace folder path
+        assert len(targets) > 0
+        assert isinstance(targets, set)
+
+    def test_get_expected_mount_targets_includes_extra_mounts(self):
+        """Test that extra mounts are included in expected targets."""
+        from pathlib import Path
+
+        from lsp_client.server.container import BindMount
+
+        extra_mount = BindMount(source="/host/path", target="/container/path")
+        server = ContainerServer(image="test-image", mounts=[extra_mount])
+        workspace = Workspace(
+            {
+                "root": WorkspaceFolder(
+                    uri="file:///test/path",
+                    name="root",
+                )
+            }
+        )
+
+        targets = server._get_expected_mount_targets(workspace)
+
+        assert "/container/path" in targets


### PR DESCRIPTION
## Summary

- Add support for container reuse to improve performance and reduce container creation overhead
- Introduce `auto_remove` flag (default: True) to control container lifecycle behavior
- Implement deterministic container naming using xxhash based on image and workspace ID
- Add workspace ID generation for consistent identification across sessions

## Changes

### Dependencies
- Added `xxhash>=3.6.0` for generating deterministic hash-based container names

### Container Server (`src/lsp_client/server/container.py`)
- Added `auto_remove` field (default: True) to control whether containers are automatically removed on exit
- Implemented `_generate_hash_name()` method to create deterministic container names based on image and workspace ID
- Added `_container_exists()` method to check if a container already exists
- Modified `format_args()` to conditionally apply `--rm` flag based on `auto_remove` setting
- Enhanced `setup()` to reuse existing containers when `auto_remove` is False

### Workspace (`src/lsp_client/utils/workspace.py`)
- Added `id` property that generates a deterministic hash based on workspace folders
- Uses xxhash for consistent workspace identification across sessions

## Benefits

- **Performance**: Reusing containers eliminates startup overhead for repeated workspace sessions
- **Backward Compatible**: Default behavior (`auto_remove=True`) maintains existing functionality
- **Flexible**: Users can opt into container reuse by setting `auto_remove=False`
- **Deterministic**: Hash-based naming ensures the same workspace always uses the same container