### PR TITLE
feat: implement workspace/didChangeWorkspaceFolders notification

### DIFF
--- a/src/lsp_client/capability/notification/__init__.py
+++ b/src/lsp_client/capability/notification/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Final
 
 from .did_change_configuration import WithNotifyDidChangeConfiguration
+from .did_change_workspace_folders import WithNotifyDidChangeWorkspaceFolders
 from .did_create_files import WithNotifyDidCreateFiles
 from .did_delete_files import WithNotifyDidDeleteFiles
 from .did_rename_files import WithNotifyDidRenameFiles
@@ -10,6 +11,7 @@ from .text_document_synchronize import WithNotifyTextDocumentSynchronize
 
 capabilities: Final = (
     WithNotifyDidChangeConfiguration,
+    WithNotifyDidChangeWorkspaceFolders,
     WithNotifyDidCreateFiles,
     WithNotifyDidRenameFiles,
     WithNotifyDidDeleteFiles,
@@ -18,6 +20,7 @@ capabilities: Final = (
 
 __all__ = [
     "WithNotifyDidChangeConfiguration",
+    "WithNotifyDidChangeWorkspaceFolders",
     "WithNotifyDidCreateFiles",
     "WithNotifyDidDeleteFiles",
     "WithNotifyDidRenameFiles",

--- a/src/lsp_client/capability/notification/did_change_workspace_folders.py
+++ b/src/lsp_client/capability/notification/did_change_workspace_folders.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Protocol, override, runtime_checkable
+
+from lsp_client.protocol import CapabilityClientProtocol, WorkspaceCapabilityProtocol
+from lsp_client.utils.types import lsp_type
+
+
+@runtime_checkable
+class WithNotifyDidChangeWorkspaceFolders(
+    WorkspaceCapabilityProtocol,
+    CapabilityClientProtocol,
+    Protocol,
+):
+    """
+    `workspace/didChangeWorkspaceFolders` - https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_didChangeWorkspaceFolders
+    """
+
+    @override
+    @classmethod
+    def iter_methods(cls) -> Iterator[str]:
+        yield from super().iter_methods()
+        yield from (lsp_type.WORKSPACE_DID_CHANGE_WORKSPACE_FOLDERS,)
+
+    @override
+    @classmethod
+    def register_workspace_capability(
+        cls, cap: lsp_type.WorkspaceClientCapabilities
+    ) -> None:
+        super().register_workspace_capability(cap)
+        cap.workspace_folders = True
+
+    async def notify_did_change_workspace_folders(
+        self,
+        added: list[lsp_type.WorkspaceFolder],
+        removed: list[lsp_type.WorkspaceFolder],
+    ) -> None:
+        """
+        Notify the server that the workspace folders have changed.
+        """
+
+        return await self.notify(
+            lsp_type.DidChangeWorkspaceFoldersNotification(
+                params=lsp_type.DidChangeWorkspaceFoldersParams(
+                    event=lsp_type.WorkspaceFoldersChangeEvent(
+                        added=added, removed=removed
+                    )
+                )
+            )
+        )

--- a/src/lsp_client/capability/notification/did_change_workspace_folders.py
+++ b/src/lsp_client/capability/notification/did_change_workspace_folders.py
@@ -31,6 +31,11 @@ class WithNotifyDidChangeWorkspaceFolders(
         super().register_workspace_capability(cap)
         cap.workspace_folders = True
 
+    @override
+    @classmethod
+    def check_server_capability(cls, cap: lsp_type.ServerCapabilities) -> None:
+        super().check_server_capability(cap)
+
     async def notify_did_change_workspace_folders(
         self,
         added: list[lsp_type.WorkspaceFolder],
@@ -38,6 +43,10 @@ class WithNotifyDidChangeWorkspaceFolders(
     ) -> None:
         """
         Notify the server that the workspace folders have changed.
+
+        Args:
+            added: Workspace folders that have been added to the workspace.
+            removed: Workspace folders that have been removed from the workspace.
         """
 
         return await self.notify(

--- a/tests/unit/test_capability/test_mixins/test_mixins.py
+++ b/tests/unit/test_capability/test_mixins/test_mixins.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 from lsp_client.capability.build import build_client_capabilities
+from lsp_client.capability.notification.did_change_workspace_folders import (
+    WithNotifyDidChangeWorkspaceFolders,
+)
 from lsp_client.capability.notification.text_document_synchronize import (
     WithNotifyTextDocumentSynchronize,
 )
@@ -34,3 +37,12 @@ def test_mixin_synchronization():
     assert capabilities.text_document is not None
     assert capabilities.text_document.synchronization is not None
     assert capabilities.text_document.synchronization.did_save is True
+
+
+def test_mixin_did_change_workspace_folders():
+    class WorkspaceFoldersClient(WithNotifyDidChangeWorkspaceFolders):
+        pass
+
+    capabilities = build_client_capabilities(WorkspaceFoldersClient)
+    assert capabilities.workspace is not None
+    assert capabilities.workspace.workspace_folders is True

--- a/tests/unit/test_capability/test_workspace_file_operations_logic.py
+++ b/tests/unit/test_capability/test_workspace_file_operations_logic.py
@@ -6,6 +6,9 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from lsprotocol import types as lsp_type
 
+from lsp_client.capability.notification.did_change_workspace_folders import (
+    WithNotifyDidChangeWorkspaceFolders,
+)
 from lsp_client.capability.notification.did_create_files import WithNotifyDidCreateFiles
 from lsp_client.capability.notification.did_delete_files import WithNotifyDidDeleteFiles
 from lsp_client.capability.notification.did_rename_files import WithNotifyDidRenameFiles
@@ -145,3 +148,21 @@ async def test_notify_did_delete_files():
     call_args = client.notify_mock.call_args[0][0]
     assert isinstance(call_args, lsp_type.DidDeleteFilesNotification)
     assert call_args.params.files[0].uri == uris[0]
+
+
+@pytest.mark.asyncio
+async def test_notify_did_change_workspace_folders():
+    class TestClient(MockClient, WithNotifyDidChangeWorkspaceFolders):
+        pass
+
+    client = TestClient()
+    added = [lsp_type.WorkspaceFolder(uri="file:///new", name="new")]
+    removed = [lsp_type.WorkspaceFolder(uri="file:///old", name="old")]
+    await client.notify_did_change_workspace_folders(added, removed)
+
+    client.notify_mock.assert_called_once()
+    call_args = client.notify_mock.call_args[0][0]
+    assert isinstance(call_args, lsp_type.DidChangeWorkspaceFoldersNotification)
+    assert call_args.params.event.added == added
+    assert call_args.params.event.removed == removed
+


### PR DESCRIPTION
## Summary
- Implemented `workspace/didChangeWorkspaceFolders` notification capability.
- Added `WithNotifyDidChangeWorkspaceFolders` mixin for clients to notify servers of workspace folder changes.
- Updated capability registration to include `workspaceFolders: True` in client capabilities.
- Added unit test to verify capability registration.