### PR TITLE
feat: support multi-root workspace for project root detection

### DIFF
--- a/src/lsp_client/clients/lang.py
+++ b/src/lsp_client/clients/lang.py
@@ -44,13 +44,19 @@ class ClientTarget(NamedTuple):
     project_path: Path
 
 
-def find_client(path: Path) -> ClientTarget | None:
-    """Identify the appropriate client and project root for a given path."""
+def find_client(path: Path, cwd: Path | None = None) -> ClientTarget | None:
+    """Identify the appropriate client and project root for a given path.
+
+    Args:
+        path: The file or directory path to find a client for.
+        cwd: Optional working directory to constrain the search. If provided,
+             only search for project roots within this directory and its subdirectories.
+    """
 
     candidates = lang_clients.values()
 
     for client_cls in candidates:
         lang_config = client_cls.get_language_config()
-        if root := lang_config.find_project_root(path):
+        if root := lang_config.find_project_root(path, cwd):
             return ClientTarget(project_path=root, client_cls=client_cls)
     return None

--- a/src/lsp_client/protocol/lang.py
+++ b/src/lsp_client/protocol/lang.py
@@ -33,8 +33,50 @@ class LanguageConfig:
     def _find_project_root(
         self, dir_path: Path, cwd: Path | None = None
     ) -> Path | None:
+        """
+        Locate the project root directory starting from ``dir_path``.
+
+        When ``cwd`` is not provided, the search walks *upwards* from
+        ``dir_path`` through its parents and returns the first directory that:
+
+        * does not contain any of the patterns in :attr:`exclude_files`, and
+        * does contain at least one of the patterns in :attr:`project_files`.
+
+        When ``cwd`` is provided, the search is restricted to directories that
+        are within ``cwd`` (i.e. ancestors of ``dir_path`` that are also
+        descendants of ``cwd``). In this case the search order is effectively
+        from ``cwd`` outward towards ``dir_path`` (closest to ``cwd`` first),
+        so that project roots nearer to the workspace root are preferred.
+
+        Directories matching :attr:`exclude_files` are treated differently
+        depending on ``cwd``:
+
+        * If ``cwd`` is ``None``, encountering an excluded directory stops the
+          search and the method returns ``None``.
+        * If ``cwd`` is not ``None``, excluded directories are skipped and the
+          search continues in other candidate directories within ``cwd``.
+
+        Parameters
+        ----------
+        dir_path:
+            Directory from which to start searching for a project root.
+        cwd:
+            Optional workspace root. If provided, ``dir_path`` must be
+            relative to ``cwd`` and the search is limited to directories that
+            are descendants of ``cwd``.
+
+        Returns
+        -------
+        Path | None
+            The detected project root directory, or ``None`` if no suitable
+            directory is found.
+        """
         if cwd is not None and not dir_path.is_relative_to(cwd):
-            raise ValueError(f"dir_path {dir_path} is not relative to cwd {cwd}")
+            raise ValueError(
+                f"Path '{dir_path.resolve()}' is not relative to the specified "
+                f"working directory '{cwd.resolve()}'. The path must be within "
+                f"the working directory or its subdirectories."
+            )
 
         paths = [dir_path, *dir_path.parents]
 
@@ -42,19 +84,55 @@ class LanguageConfig:
             paths = reversed([p for p in paths if p.is_relative_to(cwd)])
 
         for path in paths:
-            if any(list(path.glob(pattern)) for pattern in self.exclude_files):
+            if any(
+                next(path.glob(pattern), None) is not None
+                for pattern in self.exclude_files
+            ):
                 if cwd is not None:
                     continue
                 return None
 
-            if any(list(path.glob(pattern)) for pattern in self.project_files):
+            if any(
+                next(path.glob(pattern), None) is not None
+                for pattern in self.project_files
+            ):
                 return path
 
         return None
 
     def find_project_root(self, path: Path, cwd: Path | None = None) -> Path | None:
+        """Determine the project root for the given path.
+
+        The project root is the nearest ancestor directory (including the
+        directory of ``path``) that contains any of the ``project_files``
+        markers defined for this language, taking into account any
+        ``exclude_files`` markers that disqualify a directory as a project
+        root.
+
+        Parameters
+        ----------
+        path:
+            A file or directory path for which to locate the project root.
+            If a file is given, it must have a suffix listed in
+            :attr:`suffixes` or ``None`` is returned.
+        cwd:
+            Optional current working directory that constrains the search.
+            When provided, ``path`` must be relative to ``cwd``, and only
+            directories within ``cwd`` are considered as candidates for the
+            project root.
+
+        Returns
+        -------
+        Path | None
+            The path to the detected project root directory, or ``None`` if
+            no suitable project root can be found.
+        """
         if cwd is not None and not path.is_relative_to(cwd):
-            raise ValueError(f"path {path} is not relative to cwd {cwd}")
+            raise ValueError(
+                f"Path '{path.resolve()}' is not relative to the specified "
+                f"working directory '{cwd.resolve()}'. The path must be within "
+                f"the working directory or its subdirectories."
+            )
 
         if path.is_file():
             if not any(path.name.endswith(suffix) for suffix in self.suffixes):

--- a/tests/unit/test_protocol/test_lang.py
+++ b/tests/unit/test_protocol/test_lang.py
@@ -105,7 +105,7 @@ def test_find_project_root_raises_when_path_not_relative_to_cwd(
     file_path.parent.mkdir()
     file_path.write_text("pass\n")
 
-    with pytest.raises(ValueError, match="is not relative to cwd"):
+    with pytest.raises(ValueError, match="is not relative to the specified"):
         python_config.find_project_root(file_path, cwd=cwd)
 
 

--- a/tests/unit/test_protocol/test_lang.py
+++ b/tests/unit/test_protocol/test_lang.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from lsp_client.protocol.lang import LanguageConfig
+from lsp_client.utils.types import lsp_type
+
+
+@pytest.fixture
+def tmp_project(tmp_path: Path) -> Path:
+    """Create a temporary project structure for testing."""
+    project = tmp_path / "workspace" / "project"
+    project.mkdir(parents=True)
+
+    (project / "pyproject.toml").write_text("[tool.poetry]\n")
+    (project / "src").mkdir()
+    (project / "src" / "main.py").write_text("print('hello')\n")
+    (project / "src" / "subdir").mkdir()
+    (project / "src" / "subdir" / "module.py").write_text("pass\n")
+
+    return project
+
+
+@pytest.fixture
+def python_config() -> LanguageConfig:
+    return LanguageConfig(
+        kind=lsp_type.LanguageKind.Python,
+        suffixes=[".py"],
+        project_files=["pyproject.toml", "setup.py"],
+    )
+
+
+def test_find_project_root_from_file(tmp_project: Path, python_config: LanguageConfig):
+    file_path = tmp_project / "src" / "main.py"
+    result = python_config.find_project_root(file_path)
+    assert result == tmp_project
+
+
+def test_find_project_root_from_nested_file(
+    tmp_project: Path, python_config: LanguageConfig
+):
+    file_path = tmp_project / "src" / "subdir" / "module.py"
+    result = python_config.find_project_root(file_path)
+    assert result == tmp_project
+
+
+def test_find_project_root_from_directory(
+    tmp_project: Path, python_config: LanguageConfig
+):
+    dir_path = tmp_project / "src"
+    result = python_config.find_project_root(dir_path)
+    assert result == tmp_project
+
+
+def test_find_project_root_not_found(tmp_path: Path, python_config: LanguageConfig):
+    file_path = tmp_path / "random" / "file.py"
+    file_path.parent.mkdir(parents=True)
+    file_path.write_text("pass\n")
+    result = python_config.find_project_root(file_path)
+    assert result is None
+
+
+def test_find_project_root_wrong_suffix(
+    tmp_project: Path, python_config: LanguageConfig
+):
+    file_path = tmp_project / "src" / "file.txt"
+    file_path.write_text("text\n")
+    result = python_config.find_project_root(file_path)
+    assert result is None
+
+
+def test_find_project_root_with_cwd(tmp_project: Path, python_config: LanguageConfig):
+    cwd = tmp_project.parent
+    file_path = tmp_project / "src" / "main.py"
+    result = python_config.find_project_root(file_path, cwd=cwd)
+    assert result == tmp_project
+
+
+def test_find_project_root_with_cwd_closest_to_cwd(
+    tmp_path: Path, python_config: LanguageConfig
+):
+    """Test that when cwd is specified, it returns the project root closest to cwd."""
+    outer = tmp_path / "outer"
+    inner = tmp_path / "outer" / "inner"
+    inner.mkdir(parents=True)
+
+    (outer / "pyproject.toml").write_text("[tool.poetry]\n")
+    (inner / "pyproject.toml").write_text("[tool.poetry]\n")
+
+    file_path = inner / "file.py"
+    file_path.write_text("pass\n")
+
+    result = python_config.find_project_root(file_path, cwd=outer)
+    assert result == outer
+
+
+def test_find_project_root_raises_when_path_not_relative_to_cwd(
+    tmp_path: Path, python_config: LanguageConfig
+):
+    cwd = tmp_path / "workspace"
+    cwd.mkdir()
+    file_path = tmp_path / "other" / "file.py"
+    file_path.parent.mkdir()
+    file_path.write_text("pass\n")
+
+    with pytest.raises(ValueError, match="is not relative to cwd"):
+        python_config.find_project_root(file_path, cwd=cwd)
+
+
+def test_find_project_root_with_glob_pattern(tmp_path: Path):
+    config = LanguageConfig(
+        kind=lsp_type.LanguageKind.Python,
+        suffixes=[".py"],
+        project_files=["*.toml"],
+    )
+
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "pyproject.toml").write_text("[tool.poetry]\n")
+    file_path = project / "main.py"
+    file_path.write_text("pass\n")
+
+    result = config.find_project_root(file_path)
+    assert result == project
+
+
+def test_find_project_root_with_exclude_files(tmp_path: Path):
+    config = LanguageConfig(
+        kind=lsp_type.LanguageKind.Python,
+        suffixes=[".py"],
+        project_files=["pyproject.toml"],
+        exclude_files=[".git"],
+    )
+
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "pyproject.toml").write_text("[tool.poetry]\n")
+    (project / ".git").mkdir()
+    file_path = project / "main.py"
+    file_path.write_text("pass\n")
+
+    result = config.find_project_root(file_path)
+    assert result is None
+
+
+def test_find_project_root_with_exclude_files_and_cwd(tmp_path: Path):
+    """Test that when cwd is specified, excluded dirs are skipped and search continues."""
+    config = LanguageConfig(
+        kind=lsp_type.LanguageKind.Python,
+        suffixes=[".py"],
+        project_files=["pyproject.toml"],
+        exclude_files=[".git"],
+    )
+
+    outer = tmp_path / "outer"
+    inner = tmp_path / "outer" / "inner"
+    inner.mkdir(parents=True)
+
+    (outer / "pyproject.toml").write_text("[tool.poetry]\n")
+    (inner / "pyproject.toml").write_text("[tool.poetry]\n")
+    (inner / ".git").mkdir()
+
+    file_path = inner / "main.py"
+    file_path.write_text("pass\n")
+
+    result = config.find_project_root(file_path, cwd=outer)
+    assert result == outer
+
+
+def test_find_project_root_with_glob_exclude_pattern(tmp_path: Path):
+    config = LanguageConfig(
+        kind=lsp_type.LanguageKind.Python,
+        suffixes=[".py"],
+        project_files=["pyproject.toml"],
+        exclude_files=["*.git"],
+    )
+
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "pyproject.toml").write_text("[tool.poetry]\n")
+    (project / ".git").mkdir()
+    file_path = project / "main.py"
+    file_path.write_text("pass\n")
+
+    result = config.find_project_root(file_path)
+    assert result is None


### PR DESCRIPTION
## Summary

- Enhance project root detection to support multi-root workspaces
- Add `cwd` parameter to `find_project_root` to constrain search within working directory
- When `cwd` is specified, return project root closest to `cwd` instead of closest to the file
- Support glob patterns for `project_files` and `exclude_files`
- Raise `ValueError` when path is not relative to `cwd`

## Motivation

Some languages support multi-root workspaces (e.g., Cargo workspaces). Starting the LSP server at the workspace root provides additional benefits such as cross-crate navigation and workspace-wide analysis.

Constraining the search within `cwd` allows users to limit analysis to a specific sub-crate when needed, providing flexibility without sacrificing the benefits of multi-root workspace support.

## Changes

- Modified `LanguageConfig._find_project_root()` to:
  - Accept optional `cwd` parameter
  - Search from `cwd` to `dir_path` when `cwd` is provided
  - Return the project root closest to `cwd` (outermost) instead of closest to file (innermost)
  - Support glob patterns using `Path.glob()`
  - Raise `ValueError` for invalid path/cwd combinations
- Updated `LanguageConfig.find_project_root()` to pass through `cwd` parameter
- Updated `find_client()` to accept and pass through `cwd` parameter
- Added comprehensive test coverage with 12 test cases

## Testing

All existing tests pass. Added new tests covering:
- Basic project root detection
- Multi-root workspace scenarios
- Glob pattern matching
- Exclude files behavior
- Error handling for invalid paths