### PR TITLE
Refactor: simplify project root detection and add is_project_root

### DIFF
--- a/src/lsp_client/clients/lang.py
+++ b/src/lsp_client/clients/lang.py
@@ -44,19 +44,17 @@ class ClientTarget(NamedTuple):
     project_path: Path
 
 
-def find_client(path: Path, cwd: Path | None = None) -> ClientTarget | None:
+def find_client(path: Path) -> ClientTarget | None:
     """Identify the appropriate client and project root for a given path.
 
     Args:
         path: The file or directory path to find a client for.
-        cwd: Optional working directory to constrain the search. If provided,
-             only search for project roots within this directory and its subdirectories.
     """
 
     candidates = lang_clients.values()
 
     for client_cls in candidates:
         lang_config = client_cls.get_language_config()
-        if root := lang_config.find_project_root(path, cwd):
+        if root := lang_config.find_project_root(path):
             return ClientTarget(project_path=root, client_cls=client_cls)
     return None

--- a/src/lsp_client/protocol/lang.py
+++ b/src/lsp_client/protocol/lang.py
@@ -30,84 +30,31 @@ class LanguageConfig:
     exclude_files: list[str] = Factory(list)
     """Files that indicate a directory should not be considered a project root for this language."""
 
-    def _find_project_root(
-        self, dir_path: Path, cwd: Path | None = None
-    ) -> Path | None:
+    def is_project_root(self, path: Path) -> bool:
+        """Check if the given path is a project root for this language.
+
+        A directory is considered a project root if it:
+        1. Contains at least one of the patterns in :attr:`project_files`.
+        2. Does NOT contain any of the patterns in :attr:`exclude_files`.
         """
-        Locate the project root directory starting from ``dir_path``.
+        if not path.is_dir():
+            return False
 
-        When ``cwd`` is not provided, the search walks *upwards* from
-        ``dir_path`` through its parents and returns the first directory that:
+        if any(
+            next(path.glob(pattern), None) is not None for pattern in self.exclude_files
+        ):
+            return False
 
-        * does not contain any of the patterns in :attr:`exclude_files`, and
-        * does contain at least one of the patterns in :attr:`project_files`.
+        return any(
+            next(path.glob(pattern), None) is not None for pattern in self.project_files
+        )
 
-        When ``cwd`` is provided, the search is restricted to directories that
-        are within ``cwd`` (i.e. ancestors of ``dir_path`` that are also
-        descendants of ``cwd``). In this case the search order is effectively
-        from ``cwd`` outward towards ``dir_path`` (closest to ``cwd`` first),
-        so that project roots nearer to the workspace root are preferred.
-
-        Directories matching :attr:`exclude_files` are treated differently
-        depending on ``cwd``:
-
-        * If ``cwd`` is ``None``, encountering an excluded directory stops the
-          search and the method returns ``None``.
-        * If ``cwd`` is not ``None``, excluded directories are skipped and the
-          search continues in other candidate directories within ``cwd``.
-
-        Parameters
-        ----------
-        dir_path:
-            Directory from which to start searching for a project root.
-        cwd:
-            Optional workspace root. If provided, ``dir_path`` must be
-            relative to ``cwd`` and the search is limited to directories that
-            are descendants of ``cwd``.
-
-        Returns
-        -------
-        Path | None
-            The detected project root directory, or ``None`` if no suitable
-            directory is found.
-        """
-        if cwd is not None and not dir_path.is_relative_to(cwd):
-            raise ValueError(
-                f"Path '{dir_path.resolve()}' is not relative to the specified "
-                f"working directory '{cwd.resolve()}'. The path must be within "
-                f"the working directory or its subdirectories."
-            )
-
-        paths = [dir_path, *dir_path.parents]
-
-        if cwd is not None:
-            paths = reversed([p for p in paths if p.is_relative_to(cwd)])
-
-        for path in paths:
-            if any(
-                next(path.glob(pattern), None) is not None
-                for pattern in self.exclude_files
-            ):
-                if cwd is not None:
-                    continue
-                return None
-
-            if any(
-                next(path.glob(pattern), None) is not None
-                for pattern in self.project_files
-            ):
-                return path
-
-        return None
-
-    def find_project_root(self, path: Path, cwd: Path | None = None) -> Path | None:
+    def find_project_root(self, path: Path) -> Path | None:
         """Determine the project root for the given path.
 
         The project root is the nearest ancestor directory (including the
-        directory of ``path``) that contains any of the ``project_files``
-        markers defined for this language, taking into account any
-        ``exclude_files`` markers that disqualify a directory as a project
-        root.
+        directory of ``path``) that is a project root according to
+        :meth:`is_project_root`.
 
         Parameters
         ----------
@@ -115,11 +62,6 @@ class LanguageConfig:
             A file or directory path for which to locate the project root.
             If a file is given, it must have a suffix listed in
             :attr:`suffixes` or ``None`` is returned.
-        cwd:
-            Optional current working directory that constrains the search.
-            When provided, ``path`` must be relative to ``cwd``, and only
-            directories within ``cwd`` are considered as candidates for the
-            project root.
 
         Returns
         -------
@@ -127,16 +69,13 @@ class LanguageConfig:
             The path to the detected project root directory, or ``None`` if
             no suitable project root can be found.
         """
-        if cwd is not None and not path.is_relative_to(cwd):
-            raise ValueError(
-                f"Path '{path.resolve()}' is not relative to the specified "
-                f"working directory '{cwd.resolve()}'. The path must be within "
-                f"the working directory or its subdirectories."
-            )
-
         if path.is_file():
             if not any(path.name.endswith(suffix) for suffix in self.suffixes):
                 return None
             path = path.parent
 
-        return self._find_project_root(path, cwd)
+        for p in [path, *path.parents]:
+            if self.is_project_root(p):
+                return p
+
+        return None


### PR DESCRIPTION
## Summary
- Simplified project root detection by removing `cwd` constraints and logic.
- Added `is_project_root` method to `LanguageConfig` to explicitly check if a directory is a project root.
- Updated `find_project_root` to walk up from the starting path and return the first directory that satisfies `is_project_root`.
- Removed `cwd` parameter from `find_client` to align with the simplified logic.
- Updated and added unit tests to cover the new method and ensure correct behavior.