### PR TITLE
feat: add workdir config to container server

### DIFF
--- a/src/lsp_client/server/container.py
+++ b/src/lsp_client/server/container.py
@@ -185,7 +185,7 @@ class ContainerServer(StreamServer):
         suitable for reuse (i.e. can be started with `start -ai`).
         """
         try:
-            # Query the container's state; Docker/Podman expose it via .State.Status
+            # Query the container's state; using a format compatible with most OCI runtimes
             result = await anyio.run_process(
                 [self.backend, "inspect", "--format={{.State.Status}}", name],
                 stdout=subprocess.PIPE,
@@ -196,6 +196,7 @@ class ContainerServer(StreamServer):
             return False
 
         state = (result.stdout or b"").decode().strip().lower()
+        # Common OCI container states suitable for 'start'
         if state in ("exited", "created"):
             return True
 

--- a/src/lsp_client/server/container.py
+++ b/src/lsp_client/server/container.py
@@ -206,40 +206,6 @@ class ContainerServer(StreamServer):
         )
         return False
 
-    def _get_expected_mount_targets(self, workspace: Workspace) -> set[str]:
-        """
-        Get the set of expected mount targets for the current workspace.
-
-        Returns a set of target paths that should be mounted.
-        """
-        mounts = list(self.mounts)
-        folders = workspace.to_folders()
-
-        mounts.extend(
-            BindMount.from_path(
-                folder.path, readonly=True, target=folder.path.as_posix()
-            )
-            for folder in folders
-        )
-
-        targets = set()
-        for mount in mounts:
-            if isinstance(mount, Path):
-                mount_obj = BindMount.from_path(mount)
-                targets.add(mount_obj.target)
-            elif isinstance(mount, str):
-                # Parse mount string to extract target
-                # Format: type=...,source=...,target=...,readonly
-                parts = mount.split(",")
-                for part in parts:
-                    if part.startswith("target="):
-                        targets.add(part.split("=", 1)[1])
-                        break
-            else:
-                targets.add(mount.target)
-
-        return targets
-
     @override
     async def check_availability(self) -> None:
         try:

--- a/src/lsp_client/server/container.py
+++ b/src/lsp_client/server/container.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from typing import Literal, final, override
 
 import anyio
-import xxhash
 from anyio.abc import AnyByteReceiveStream, AnyByteSendStream
 from attrs import Factory, define, field
 from loguru import logger
@@ -174,13 +173,11 @@ class ContainerServer(StreamServer):
     def _generate_hash_name(self, workspace: Workspace) -> str:
         """Generate a deterministic container name for a workspace.
 
-        The name is derived from the container image and the workspace ID so
-        that the same workspace gets the same container name across sessions,
-        enabling container reuse when auto_remove is disabled.
+        The name is derived from the workspace ID so that the same workspace
+        gets the same container name across sessions, enabling container reuse
+        when auto_remove is disabled.
         """
-        hash_input = f"{self.image}:{workspace.id}:{self.workdir or ''}"
-        path_hash = xxhash.xxh32_hexdigest(hash_input.encode(), seed=0)
-        return f"lsp-server-{path_hash}"
+        return f"lsp-server-{workspace.id}"
 
     async def _container_exists(self, name: str) -> bool:
         """


### PR DESCRIPTION
## Summary
- Added `workdir` parameter to `ContainerServer` with automatic inference for single-folder workspaces.
- Removed `auto_remove` parameter; containers now always use `--rm` when started via `run`.
- Cleaned up unused methods and imports.