### PR TITLE
feat: disable container-based servers by default

### DIFF
--- a/src/lsp_client/client/abc.py
+++ b/src/lsp_client/client/abc.py
@@ -33,6 +33,7 @@ from lsp_client.protocol import CapabilityClientProtocol, CapabilityProtocol
 from lsp_client.server import DefaultServers, ServerRuntimeError
 from lsp_client.server.abc import Server
 from lsp_client.server.types import ServerRequest
+from lsp_client.settings import settings
 from lsp_client.utils.channel import Receiver, channel
 from lsp_client.utils.config import ConfigurationMap
 from lsp_client.utils.types import AnyPath, Notification, Request, Response, lsp_type
@@ -125,7 +126,8 @@ class Client(
             await defaults.local.check_availability()
             yield defaults.local
 
-        yield defaults.container
+        if settings.enable_container:
+            yield defaults.container
         yield defaults.local
 
     @asynccontextmanager

--- a/src/lsp_client/settings.py
+++ b/src/lsp_client/settings.py
@@ -11,6 +11,7 @@ class Settings(BaseSettings):
     )
 
     disable_auto_installation: bool = False
+    enable_container: bool = False
 
 
 settings = Settings()


### PR DESCRIPTION
## Summary
Disable container-based servers by default and introduce an environment variable `LSP_CLIENT_ENABLE_CONTAINER` to enable them.

## Motivation
Containerized servers are more complex and require thorough testing before being ready for production. This PR temporarily disables them to prevent unexpected issues, while still allowing developers to enable them for testing.

## Changes
- Add `enable_container` setting (default `False`) in `settings.py`.
- Check `enable_container` in `ContainerServer.setup` and `check_availability`.
- Only yield `defaults.container` in `Client._iter_candidate_servers` if enabled.