### PR TITLE
feat: add get_root_path method for single-root workspace

### DIFF
--- a/src/lsp_client/client/abc.py
+++ b/src/lsp_client/client/abc.py
@@ -38,7 +38,7 @@ from lsp_client.utils.channel import Receiver, channel
 from lsp_client.utils.config import ConfigurationMap
 from lsp_client.utils.types import AnyPath, Notification, Request, Response, lsp_type
 from lsp_client.utils.workspace import (
-    DEFAULT_WORKSPACE_DIR,
+    WORKSPACE_ROOT_DIR,
     RawWorkspace,
     Workspace,
     format_workspace,
@@ -378,7 +378,7 @@ class Client(
             tg.soonify(self._dispatch_server_requests)(receiver)
 
             client_capabilities = build_client_capabilities(self.__class__)
-            root_workspace = self.get_workspace().get(DEFAULT_WORKSPACE_DIR)
+            root_workspace = self.get_workspace().get(WORKSPACE_ROOT_DIR)
             root_path = root_workspace.path.as_posix() if root_workspace else None
             root_uri = root_workspace.uri if root_workspace else None
 

--- a/src/lsp_client/protocol/client.py
+++ b/src/lsp_client/protocol/client.py
@@ -16,7 +16,7 @@ from lsp_client.client.document_state import DocumentStateManager
 from lsp_client.utils.config import ConfigurationMap
 from lsp_client.utils.types import AnyPath, Notification, Request, Response
 from lsp_client.utils.uri import from_local_uri
-from lsp_client.utils.workspace import DEFAULT_WORKSPACE_DIR, Workspace
+from lsp_client.utils.workspace import WORKSPACE_ROOT_DIR, Workspace
 
 from .lang import LanguageConfig
 
@@ -87,7 +87,7 @@ class CapabilityClientProtocol(Protocol):
             return file_path.as_uri()
 
         if len(self.get_workspace()) == 1:  # single root workspace
-            folder = self.get_workspace()[DEFAULT_WORKSPACE_DIR]
+            folder = self.get_workspace()[WORKSPACE_ROOT_DIR]
             return (folder.path / file_path).as_uri()
         # multi-root workspace
         if (root := file_path.parts[0]) not in self.get_workspace():
@@ -106,8 +106,8 @@ class CapabilityClientProtocol(Protocol):
             return path
 
         workspace = self.get_workspace()
-        if len(workspace) == 1 and DEFAULT_WORKSPACE_DIR in workspace:
-            folder = workspace[DEFAULT_WORKSPACE_DIR]
+        if len(workspace) == 1 and WORKSPACE_ROOT_DIR in workspace:
+            folder = workspace[WORKSPACE_ROOT_DIR]
             if path.is_relative_to(folder.path):
                 return path.relative_to(folder.path)
             return path

--- a/src/lsp_client/utils/workspace.py
+++ b/src/lsp_client/utils/workspace.py
@@ -68,14 +68,25 @@ class Workspace(dict[str, WorkspaceFolder]):
             "|".join(f"{name}:{folder.uri}" for name, folder in items).encode()
         )
 
+    def get_root_path(self) -> Path | None:
+        """
+        Return the path of the root workspace folder.
+
+        Return None if workspace is a multi-root workspace.
+        """
+
+        if folder := self.get(WORKSPACE_ROOT_DIR):
+            return folder.path
+        return None
+
 
 DEFAULT_WORKSPACE_PATH = Path.cwd()
-DEFAULT_WORKSPACE_DIR: Final = "__root__"
+WORKSPACE_ROOT_DIR: Final = "__root__"
 DEFAULT_WORKSPACE: Final[Workspace] = Workspace(
     {
-        DEFAULT_WORKSPACE_DIR: WorkspaceFolder(
+        WORKSPACE_ROOT_DIR: WorkspaceFolder(
             uri=Path.cwd().as_uri(),
-            name=DEFAULT_WORKSPACE_DIR,
+            name=WORKSPACE_ROOT_DIR,
         )
     }
 )
@@ -88,7 +99,7 @@ def format_workspace(raw: RawWorkspace) -> Workspace:
         case str() | os.PathLike() as root_folder_path:
             return Workspace(
                 {
-                    DEFAULT_WORKSPACE_DIR: WorkspaceFolder(
+                    WORKSPACE_ROOT_DIR: WorkspaceFolder(
                         uri=Path(root_folder_path).resolve().as_uri(),
                         name="root",
                     )

--- a/tests/unit/test_protocol/test_client.py
+++ b/tests/unit/test_protocol/test_client.py
@@ -11,7 +11,7 @@ from lsp_client.protocol.client import CapabilityClientProtocol
 from lsp_client.protocol.lang import LanguageConfig
 from lsp_client.utils.config import ConfigurationMap
 from lsp_client.utils.types import AnyPath, Notification, Request, Response, lsp_type
-from lsp_client.utils.workspace import DEFAULT_WORKSPACE_DIR, Workspace, WorkspaceFolder
+from lsp_client.utils.workspace import WORKSPACE_ROOT_DIR, Workspace, WorkspaceFolder
 
 
 class MockClient(CapabilityClientProtocol):
@@ -57,8 +57,8 @@ class MockClient(CapabilityClientProtocol):
 def test_capability_client_protocol_as_uri():
     workspace = Workspace()
     path = Path("/test/project")
-    workspace[DEFAULT_WORKSPACE_DIR] = WorkspaceFolder(
-        uri=path.as_uri(), name=DEFAULT_WORKSPACE_DIR
+    workspace[WORKSPACE_ROOT_DIR] = WorkspaceFolder(
+        uri=path.as_uri(), name=WORKSPACE_ROOT_DIR
     )
     client = MockClient(workspace)
 
@@ -94,8 +94,8 @@ def test_capability_client_protocol_as_uri_multi_root():
 def test_capability_client_protocol_from_uri():
     workspace = Workspace()
     path = Path("/test/project/file.py")
-    workspace[DEFAULT_WORKSPACE_DIR] = WorkspaceFolder(
-        uri=Path("/test/project").as_uri(), name=DEFAULT_WORKSPACE_DIR
+    workspace[WORKSPACE_ROOT_DIR] = WorkspaceFolder(
+        uri=Path("/test/project").as_uri(), name=WORKSPACE_ROOT_DIR
     )
     client = MockClient(workspace)
 


### PR DESCRIPTION
## Summary
- Added `get_root_path` method to `Workspace` class to conveniently retrieve the root path in single-root configurations.
- Renamed `DEFAULT_WORKSPACE_DIR` to `WORKSPACE_ROOT_DIR` for better clarity.
- Updated internal references and tests to use the new constant.