### PR TITLE
feat: Better Code Action Support

### DIFF
--- a/src/lsp_client/capability/request/__init__.py
+++ b/src/lsp_client/capability/request/__init__.py
@@ -10,6 +10,7 @@ from .completion import WithRequestCompletion
 from .declaration import WithRequestDeclaration
 from .definition import WithRequestDefinition
 from .document_symbol import WithRequestDocumentSymbol
+from .execute_command import WithRequestExecuteCommand
 from .hover import WithRequestHover
 from .implementation import WithRequestImplementation
 from .inlay_hint import WithRequestInlayHint
@@ -31,6 +32,7 @@ capabilities: Final = (
     WithRequestDeclaration,
     WithRequestDefinition,
     WithRequestDocumentSymbol,
+    WithRequestExecuteCommand,
     WithRequestHover,
     WithRequestImplementation,
     WithRequestInlayHint,
@@ -56,6 +58,7 @@ __all__ = [
     "WithRequestDeclaration",
     "WithRequestDefinition",
     "WithRequestDocumentSymbol",
+    "WithRequestExecuteCommand",
     "WithRequestHover",
     "WithRequestImplementation",
     "WithRequestInlayHint",

--- a/src/lsp_client/capability/request/code_action.py
+++ b/src/lsp_client/capability/request/code_action.py
@@ -138,15 +138,16 @@ class WithRequestCodeAction(
         if item.edit is None and item.command is None:
             item = await self.request_code_action_resolve(item)
 
+        if item.command is not None and not hasattr(self, "request_execute_command"):
+            raise RuntimeError(
+                "executeCommand capability not available. Include WithRequestExecuteCommand mixin."
+            )
+
         if item.edit is not None:
             await self.apply_workspace_edit(item.edit)
 
         if item.command is not None:
-            method = getattr(self, "request_execute_command", None)
-            if method is None:
-                raise RuntimeError(
-                    "executeCommand capability not available. Include WithRequestExecuteCommand mixin."
-                )
+            method = self.request_execute_command
             await method(item.command.command, item.command.arguments)
 
     async def apply_code_actions(

--- a/src/lsp_client/capability/request/execute_command.py
+++ b/src/lsp_client/capability/request/execute_command.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any, Protocol, override, runtime_checkable
+
+from lsp_client.jsonrpc.id import jsonrpc_uuid
+from lsp_client.protocol import CapabilityClientProtocol, WorkspaceCapabilityProtocol
+from lsp_client.utils.types import lsp_type
+
+
+@runtime_checkable
+class WithRequestExecuteCommand(
+    WorkspaceCapabilityProtocol,
+    CapabilityClientProtocol,
+    Protocol,
+):
+    """
+    `workspace/executeCommand` - https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_executeCommand
+    """
+
+    @override
+    @classmethod
+    def iter_methods(cls) -> Iterator[str]:
+        yield from super().iter_methods()
+        yield from (lsp_type.WORKSPACE_EXECUTE_COMMAND,)
+
+    @override
+    @classmethod
+    def register_workspace_capability(
+        cls, cap: lsp_type.WorkspaceClientCapabilities
+    ) -> None:
+        super().register_workspace_capability(cap)
+        cap.execute_command = lsp_type.ExecuteCommandClientCapabilities()
+
+    @override
+    @classmethod
+    def check_server_capability(cls, cap: lsp_type.ServerCapabilities) -> None:
+        super().check_server_capability(cap)
+        assert cap.execute_command_provider
+
+    async def _request_execute_command(
+        self, params: lsp_type.ExecuteCommandParams
+    ) -> Any:  # noqa: ANN401
+        return await self.request(
+            lsp_type.ExecuteCommandRequest(
+                id=jsonrpc_uuid(),
+                params=params,
+            ),
+            schema=lsp_type.ExecuteCommandResponse,
+        )
+
+    async def request_execute_command(
+        self, command: str, arguments: list[Any] | None = None
+    ) -> Any:  # noqa: ANN401
+        return await self._request_execute_command(
+            lsp_type.ExecuteCommandParams(
+                command=command,
+                arguments=arguments,
+            )
+        )

--- a/tests/unit/capability/request/test_code_action.py
+++ b/tests/unit/capability/request/test_code_action.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import contextlib
+from collections.abc import AsyncGenerator
+from typing import Any, override
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from lsp_client.capability.request.code_action import WithRequestCodeAction
+from lsp_client.protocol import CapabilityClientProtocol
+from lsp_client.utils.types import Request, Response, lsp_type
+
+
+class MockCodeActionClient(WithRequestCodeAction, CapabilityClientProtocol):
+    request_mock: AsyncMock
+    apply_workspace_edit_mock: AsyncMock
+    request_execute_command_mock: AsyncMock
+    workspace: MagicMock
+
+    def __init__(self) -> None:
+        self.request_mock = AsyncMock()
+        self.apply_workspace_edit_mock = AsyncMock()
+        self.request_execute_command_mock = AsyncMock()
+        self.workspace = MagicMock()
+        self.workspace.values.return_value = []
+
+    @override
+    async def request[R](self, req: Request, schema: type[Response[R]]) -> R:
+        return await self.request_mock(req, schema)
+
+    @override
+    async def apply_workspace_edit(self, edit: lsp_type.WorkspaceEdit) -> None:
+        await self.apply_workspace_edit_mock(edit)
+
+    async def request_execute_command(
+        self, command: str, arguments: list[Any] | None = None
+    ) -> Any:
+        return await self.request_execute_command_mock(command, arguments)
+
+    @override
+    def get_document_state(self) -> Any: ...
+    @override
+    def get_workspace(self) -> Any:
+        return self.workspace
+
+    @override
+    def get_config_map(self) -> Any: ...
+    @override
+    @classmethod
+    def get_language_config(cls) -> Any: ...
+
+    @override
+    @contextlib.asynccontextmanager
+    async def open_files(self, *args: Any, **kwargs: Any) -> AsyncGenerator[None]:
+        yield
+
+    @override
+    async def write_file(self, *args: Any, **kwargs: Any) -> Any: ...
+    @override
+    async def read_file(self, *args: Any, **kwargs: Any) -> Any: ...
+    @override
+    async def notify(self, *args: Any, **kwargs: Any) -> Any: ...
+
+    @override
+    def as_uri(self, file_path: Any) -> str:
+        return f"file://{file_path}"
+
+
+@pytest.mark.asyncio
+async def test_apply_code_action_command_only() -> None:
+    client = MockCodeActionClient()
+    command = lsp_type.Command(title="Test", command="test.command", arguments=["arg1"])
+
+    await client.apply_code_action(command)
+
+    client.request_execute_command_mock.assert_called_once_with(
+        "test.command", ["arg1"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_apply_code_action_code_action_edit_only() -> None:
+    client = MockCodeActionClient()
+    edit = lsp_type.WorkspaceEdit(changes={"file1": []})
+    action = lsp_type.CodeAction(title="Test", edit=edit)
+
+    await client.apply_code_action(action)
+
+    client.apply_workspace_edit_mock.assert_called_once_with(edit)
+    client.request_execute_command_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_apply_code_action_code_action_command_only() -> None:
+    client = MockCodeActionClient()
+    command = lsp_type.Command(title="Test", command="test.command", arguments=["arg1"])
+    action = lsp_type.CodeAction(title="Test", command=command)
+
+    await client.apply_code_action(action)
+
+    client.apply_workspace_edit_mock.assert_not_called()
+    client.request_execute_command_mock.assert_called_once_with(
+        "test.command", ["arg1"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_apply_code_action_both_edit_and_command() -> None:
+    client = MockCodeActionClient()
+    edit = lsp_type.WorkspaceEdit(changes={"file1": []})
+    command = lsp_type.Command(title="Test", command="test.command", arguments=["arg1"])
+    action = lsp_type.CodeAction(title="Test", edit=edit, command=command)
+
+    await client.apply_code_action(action)
+
+    client.apply_workspace_edit_mock.assert_called_once_with(edit)
+    client.request_execute_command_mock.assert_called_once_with(
+        "test.command", ["arg1"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_apply_code_action_lazy_resolve() -> None:
+    client = MockCodeActionClient()
+    action = lsp_type.CodeAction(title="Test")
+
+    resolved_edit = lsp_type.WorkspaceEdit(changes={"file2": []})
+    resolved_action = lsp_type.CodeAction(title="Test", edit=resolved_edit)
+    client.request_mock.return_value = resolved_action
+
+    await client.apply_code_action(action)
+
+    client.request_mock.assert_called_once()
+    req, _ = client.request_mock.call_args[0]
+    assert isinstance(req, lsp_type.CodeActionResolveRequest)
+
+    client.apply_workspace_edit_mock.assert_called_once_with(resolved_edit)
+
+
+@pytest.mark.asyncio
+async def test_apply_code_action_disabled() -> None:
+    client = MockCodeActionClient()
+    action = lsp_type.CodeAction(
+        title="Test", disabled=lsp_type.CodeActionDisabled(reason="reason")
+    )
+
+    await client.apply_code_action(action)
+
+    client.apply_workspace_edit_mock.assert_not_called()
+    client.request_execute_command_mock.assert_not_called()
+    client.request_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_apply_code_actions_multiple() -> None:
+    client = MockCodeActionClient()
+    action1 = lsp_type.CodeAction(title="Action 1", edit=lsp_type.WorkspaceEdit())
+    action2 = lsp_type.Command(title="Command 2", command="cmd2")
+
+    await client.apply_code_actions([action1, action2])
+
+    client.apply_workspace_edit_mock.assert_called_once()
+    client.request_execute_command_mock.assert_called_once_with("cmd2", None)
+
+
+@pytest.mark.asyncio
+async def test_apply_code_action_missing_execute_command_capability() -> None:
+    class PartialClient(WithRequestCodeAction, CapabilityClientProtocol):
+        apply_workspace_edit_mock: AsyncMock
+
+        def __init__(self) -> None:
+            self.apply_workspace_edit_mock = AsyncMock()
+
+        @override
+        async def request[R](self, req: Request, schema: type[Response[R]]) -> R:
+            raise NotImplementedError()  # type: ignore[misc]
+
+        @override
+        async def apply_workspace_edit(self, edit: lsp_type.WorkspaceEdit) -> None:
+            await self.apply_workspace_edit_mock(edit)
+
+        @override
+        def get_document_state(self) -> Any:
+            raise NotImplementedError()
+
+        @override
+        def get_workspace(self) -> Any:
+            raise NotImplementedError()
+
+        @override
+        def get_config_map(self) -> Any:
+            raise NotImplementedError()
+
+        @override
+        @classmethod
+        def get_language_config(cls) -> Any:
+            raise NotImplementedError()
+
+        @override
+        @contextlib.asynccontextmanager
+        async def open_files(self, *args: Any, **kwargs: Any) -> AsyncGenerator[None]:
+            yield
+
+        @override
+        async def write_file(self, *args: Any, **kwargs: Any) -> Any: ...
+        @override
+        async def read_file(self, *args: Any, **kwargs: Any) -> Any: ...
+        @override
+        async def notify(self, *args: Any, **kwargs: Any) -> Any: ...
+        @override
+        def as_uri(self, file_path: Any) -> str:
+            return ""
+
+    client = PartialClient()
+    command = lsp_type.Command(title="Test", command="test.command")
+
+    with pytest.raises(RuntimeError, match="executeCommand capability not available"):
+        await client.apply_code_action(command)

--- a/tests/unit/capability/request/test_execute_command.py
+++ b/tests/unit/capability/request/test_execute_command.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import contextlib
+from collections.abc import AsyncGenerator
+from typing import Any, override
+from unittest.mock import AsyncMock
+
+import pytest
+
+from lsp_client.capability.request.execute_command import WithRequestExecuteCommand
+from lsp_client.protocol import CapabilityClientProtocol
+from lsp_client.utils.types import Request, Response, lsp_type
+
+
+class MockClient(WithRequestExecuteCommand, CapabilityClientProtocol):
+    request_mock: AsyncMock
+
+    def __init__(self) -> None:
+        self.request_mock = AsyncMock()
+
+    @override
+    async def request[R](self, req: Request, schema: type[Response[R]]) -> R:
+        return await self.request_mock(req, schema)
+
+    @override
+    def get_document_state(self) -> Any: ...
+    @override
+    def get_workspace(self) -> Any: ...
+    @override
+    def get_config_map(self) -> Any: ...
+    @override
+    @classmethod
+    def get_language_config(cls) -> Any: ...
+
+    @override
+    @contextlib.asynccontextmanager
+    async def open_files(self, *args: Any, **kwargs: Any) -> AsyncGenerator[None]:
+        yield
+
+    @override
+    async def write_file(self, *args: Any, **kwargs: Any) -> Any: ...
+    @override
+    async def read_file(self, *args: Any, **kwargs: Any) -> Any: ...
+    @override
+    async def notify(self, *args: Any, **kwargs: Any) -> Any: ...
+
+
+@pytest.mark.asyncio
+async def test_request_execute_command() -> None:
+    client = MockClient()
+    client.request_mock.return_value = "command_result"
+
+    result = await client.request_execute_command("test.command", ["arg1", 42])
+
+    assert result == "command_result"
+    client.request_mock.assert_called_once()
+    req, schema = client.request_mock.call_args[0]
+
+    assert isinstance(req, lsp_type.ExecuteCommandRequest)
+    assert req.method == lsp_type.WORKSPACE_EXECUTE_COMMAND
+    assert req.params.command == "test.command"
+    assert req.params.arguments == ["arg1", 42]
+    assert schema == lsp_type.ExecuteCommandResponse
+
+
+def test_execute_command_capability_check() -> None:
+    class TestClient(WithRequestExecuteCommand):
+        @override
+        def get_document_state(self) -> Any: ...
+        @override
+        def get_workspace(self) -> Any: ...
+        @override
+        def get_config_map(self) -> Any: ...
+        @override
+        @classmethod
+        def get_language_config(cls) -> Any: ...
+        @override
+        @contextlib.asynccontextmanager
+        async def open_files(self, *args: Any, **kwargs: Any) -> AsyncGenerator[None]:
+            yield
+
+        @override
+        async def request(self, *args: Any, **kwargs: Any) -> Any: ...
+        @override
+        async def notify(self, *args: Any, **kwargs: Any) -> Any: ...
+        @override
+        async def read_file(self, *args: Any, **kwargs: Any) -> Any: ...
+        @override
+        async def write_file(self, *args: Any, **kwargs: Any) -> Any: ...
+
+    caps = lsp_type.ServerCapabilities(
+        execute_command_provider=lsp_type.ExecuteCommandOptions(commands=["cmd"])
+    )
+    TestClient.check_server_capability(caps)
+
+    caps = lsp_type.ServerCapabilities(execute_command_provider=None)
+    with pytest.raises(AssertionError):
+        TestClient.check_server_capability(caps)


### PR DESCRIPTION
## Summary

This PR implements comprehensive code action application support for lsp-client, addressing issue #35.

## Changes

### New Capabilities

1. **`WithRequestExecuteCommand`** - New capability for `workspace/executeCommand`
   - Enables execution of LSP commands returned from code actions
   - Properly registered in workspace client capabilities
   - Full server capability validation

2. **Enhanced `WithRequestCodeAction`** - Apply methods for code actions
   - `apply_code_action(item)` - Apply a single code action or command
   - `apply_code_actions(items)` - Apply multiple actions sequentially
   - Auto-resolve lazy code actions (when edit/command are missing)
   - Proper handling of disabled code actions (skips them)
   - Clear error messages when executeCommand capability is missing

### Implementation Details

- **WorkspaceEdit Application**: Integrates with existing `WithApplyWorkspaceEdit` mixin
- **Command Execution**: Checks for `WithRequestExecuteCommand` capability at runtime
- **LSP Compliance**: Follows spec - applies edit first, then executes command
- **Sequential Application**: Bulk operations applied one-by-one to avoid range conflicts

### Testing

- **10 comprehensive unit tests** covering all scenarios:
  - Command-only application
  - CodeAction with edit only
  - CodeAction with command only
  - CodeAction with both edit and command
  - Lazy CodeAction resolution
  - Disabled CodeAction handling
  - Bulk application
  - Missing capability error handling

All tests pass ✅

## Usage Example

\`\`\`python
from lsp_client import PyrightClient, Position
from lsp_client.capability.request import WithRequestExecuteCommand

# Client with both code action and executeCommand capabilities
class MyPyrightClient(
    PyrightClient,
    WithRequestExecuteCommand,  # Add executeCommand support
):
    pass

async with MyPyrightClient() as client:
    # Get code actions
    actions = await client.request_code_action(
        file_path="example.py",
        range=Range(Position(10, 0), Position(10, 20))
    )
    
    # Apply a single action (handles both edit and command)
    if actions:
        await client.apply_code_action(actions[0])
    
    # Or apply all actions
    await client.apply_code_actions(actions)
\`\`\`

## Verification

- ✅ Type checking: `ty check` passes
- ✅ Linting: `ruff check` passes
- ✅ Unit tests: 10/10 tests pass
- ✅ Pre-commit hooks: All pass
- ✅ No breaking changes to existing API

## Closes

Closes #35

## Checklist

- [x] WithRequestExecuteCommand capability implemented
- [x] apply_code_action() handles both Command and CodeAction
- [x] apply_code_actions() for bulk application
- [x] Auto-resolve for lazy code actions
- [x] Clear error when executeCommand missing
- [x] Unit tests pass
- [x] Type checking passes
- [x] Linting passes
- [x] No breaking changes to existing API