### PR TITLE
feat: enhance automatic installation with generic helpers

### DIFF
--- a/src/lsp_client/capability/request/__init__.py
+++ b/src/lsp_client/capability/request/__init__.py
@@ -10,6 +10,7 @@ from .completion import WithRequestCompletion
 from .declaration import WithRequestDeclaration
 from .definition import WithRequestDefinition
 from .document_symbol import WithRequestDocumentSymbol
+from .execute_command import WithRequestExecuteCommand
 from .hover import WithRequestHover
 from .implementation import WithRequestImplementation
 from .inlay_hint import WithRequestInlayHint
@@ -31,6 +32,7 @@ capabilities: Final = (
     WithRequestDeclaration,
     WithRequestDefinition,
     WithRequestDocumentSymbol,
+    WithRequestExecuteCommand,
     WithRequestHover,
     WithRequestImplementation,
     WithRequestInlayHint,
@@ -56,6 +58,7 @@ __all__ = [
     "WithRequestDeclaration",
     "WithRequestDefinition",
     "WithRequestDocumentSymbol",
+    "WithRequestExecuteCommand",
     "WithRequestHover",
     "WithRequestImplementation",
     "WithRequestInlayHint",

--- a/src/lsp_client/capability/request/execute_command.py
+++ b/src/lsp_client/capability/request/execute_command.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any, Protocol, override, runtime_checkable
+
+from lsp_client.jsonrpc.id import jsonrpc_uuid
+from lsp_client.protocol import CapabilityClientProtocol, WorkspaceCapabilityProtocol
+from lsp_client.utils.types import lsp_type
+
+
+@runtime_checkable
+class WithRequestExecuteCommand(
+    WorkspaceCapabilityProtocol,
+    CapabilityClientProtocol,
+    Protocol,
+):
+    """
+    `workspace/executeCommand` - https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_executeCommand
+    """
+
+    @override
+    @classmethod
+    def iter_methods(cls) -> Iterator[str]:
+        yield from super().iter_methods()
+        yield from (lsp_type.WORKSPACE_EXECUTE_COMMAND,)
+
+    @override
+    @classmethod
+    def register_workspace_capability(
+        cls, cap: lsp_type.WorkspaceClientCapabilities
+    ) -> None:
+        super().register_workspace_capability(cap)
+        cap.execute_command = lsp_type.ExecuteCommandClientCapabilities()
+
+    @override
+    @classmethod
+    def check_server_capability(cls, cap: lsp_type.ServerCapabilities) -> None:
+        super().check_server_capability(cap)
+        assert cap.execute_command_provider
+
+    async def _request_execute_command(
+        self, params: lsp_type.ExecuteCommandParams
+    ) -> Any:  # noqa: ANN401
+        return await self.request(
+            lsp_type.ExecuteCommandRequest(
+                id=jsonrpc_uuid(),
+                params=params,
+            ),
+            schema=lsp_type.ExecuteCommandResponse,
+        )
+
+    async def request_execute_command(
+        self, command: str, arguments: list[Any] | None = None
+    ) -> Any:  # noqa: ANN401
+        return await self._request_execute_command(
+            lsp_type.ExecuteCommandParams(
+                command=command,
+                arguments=arguments,
+            )
+        )

--- a/src/lsp_client/clients/basedpyright.py
+++ b/src/lsp_client/clients/basedpyright.py
@@ -1,14 +1,10 @@
 from __future__ import annotations
 
-import shutil
 import sys
 from functools import partial
-from subprocess import CalledProcessError
 from typing import Any, override
 
-import anyio
 from attrs import define
-from loguru import logger
 
 from lsp_client.capability.notification import (
     WithNotifyDidChangeConfiguration,
@@ -47,9 +43,10 @@ from lsp_client.capability.server_request import (
     WithRespondWorkspaceFoldersRequest,
 )
 from lsp_client.clients.base import PythonClientBase
-from lsp_client.server import DefaultServers, ServerInstallationError
+from lsp_client.server import DefaultServers
 from lsp_client.server.container import ContainerServer
 from lsp_client.server.local import LocalServer
+from lsp_client.utils.install import install_via_commands
 from lsp_client.utils.types import lsp_type
 
 BasedpyrightContainerServer = partial(
@@ -57,36 +54,18 @@ BasedpyrightContainerServer = partial(
 )
 
 
-async def ensure_basedpyright_installed() -> None:
-    if shutil.which("basedpyright-langserver"):
-        return
-
-    installers = [
-        (["uv", "tool", "install", "basedpyright"], "uv"),
-        (["npm", "install", "-g", "basedpyright"], "npm"),
-        ([sys.executable, "-m", "pip", "install", "basedpyright"], "pip"),
-    ]
-
-    for cmd, name in installers:
-        if shutil.which(cmd[0]):
-            try:
-                logger.info("Attempting to install basedpyright via {}...", name)
-                await anyio.run_process(cmd)
-            except CalledProcessError:
-                continue
-            else:
-                return
-
-    raise ServerInstallationError(
-        "Could not install basedpyright. Please install it manually with 'uv tool install basedpyright', 'npm install -g basedpyright' or 'pip install basedpyright'."
-    )
-
-
 BasedpyrightLocalServer = partial(
     LocalServer,
     program="basedpyright-langserver",
     args=["--stdio"],
-    ensure_installed=ensure_basedpyright_installed,
+    ensure_installed=partial(
+        install_via_commands,
+        "basedpyright-langserver",
+        commands=(sys.executable, "-m", "pip", "install", "basedpyright"),
+        error_message=(
+            "Could not install basedpyright. Please install it manually with 'uv tool install basedpyright', 'npm install -g basedpyright' or 'pip install basedpyright'."
+        ),
+    ),
 )
 
 

--- a/src/lsp_client/utils/install.py
+++ b/src/lsp_client/utils/install.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import shutil
+import sys
+import tempfile
+from collections.abc import Sequence
+from pathlib import Path
+from subprocess import CalledProcessError
+from typing import TypedDict
+
+import anyio
+import httpx
+from loguru import logger
+
+from lsp_client.server import ServerInstallationError
+
+
+class ShellInfo(TypedDict):
+    """
+    Information about the platform's shell and script extension.
+    """
+
+    shell: str
+    extension: str
+
+
+def _get_platform_shell() -> ShellInfo:
+    """Return the system shell and its script extension."""
+    match sys.platform:
+        case "win32":
+            if shutil.which("powershell"):
+                return ShellInfo(shell="powershell", extension=".ps1")
+            return ShellInfo(shell="cmd", extension=".bat")
+        case _:
+            if shutil.which("bash"):
+                return ShellInfo(shell="bash", extension=".sh")
+            return ShellInfo(shell="sh", extension=".sh")
+
+
+async def install_via_commands(
+    binary: str,
+    commands: Sequence[str],
+    *,
+    error_message: str,
+) -> None:
+    """
+    Install a binary by executing a sequence of commands.
+
+    Args:
+        binary: The name of the binary to install.
+        commands: The commands to execute.
+        error_message: Detailed message to show if installation fails.
+    """
+    if shutil.which(binary):
+        return
+
+    logger.warning(f"{binary} not found, attempting to install...")
+    try:
+        await anyio.run_process(commands)
+        logger.info(f"Successfully installed {binary}")
+    except CalledProcessError as e:
+        msg = f"Installation of {binary} failed. {error_message}"
+        raise ServerInstallationError(msg) from e
+
+
+async def install_via_script(
+    binary: str,
+    script_url: str,
+    *,
+    error_message: str,
+) -> None:
+    """
+    Install a binary by downloading and executing a script.
+
+    Args:
+        binary: The name of the binary to install.
+        script_url: The URL to download the installation script from.
+        error_message: Detailed message to show if installation fails.
+    """
+    if shutil.which(binary):
+        return
+
+    logger.warning(f"{binary} not found, attempting to install...")
+
+    try:
+        info = _get_platform_shell()
+        shell = info["shell"]
+        ext = info["extension"]
+
+        async with httpx.AsyncClient(follow_redirects=True) as client:
+            response = await client.get(script_url)
+            response.raise_for_status()
+            script_content = response.text
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=ext, delete=False
+        ) as tmp_file:
+            tmp_file.write(script_content)
+            tmp_path = Path(tmp_file.name)
+
+        try:
+            if sys.platform != "win32":
+                tmp_path.chmod(0o755)
+
+            match (sys.platform, shell):
+                case ("win32", "powershell"):
+                    command = [
+                        "powershell",
+                        "-ExecutionPolicy",
+                        "Bypass",
+                        "-File",
+                        str(tmp_path),
+                    ]
+                case _:
+                    command = [shell, str(tmp_path)]
+
+            logger.debug(f"Executing installation script with: {' '.join(command)}")
+            await anyio.run_process(command)
+            logger.info(f"Successfully installed {binary}")
+        finally:
+            tmp_path.unlink(missing_ok=True)
+
+    except httpx.HTTPError as e:
+        msg = (
+            f"Failed to download installation script from {script_url}. {error_message}"
+        )
+        raise ServerInstallationError(msg) from e
+    except CalledProcessError as e:
+        msg = f"Installation of {binary} failed. {error_message}"
+        raise ServerInstallationError(msg) from e

--- a/tests/unit/capability/request/test_code_action.py
+++ b/tests/unit/capability/request/test_code_action.py
@@ -174,7 +174,7 @@ async def test_apply_code_action_missing_execute_command_capability() -> None:
 
         @override
         async def request[R](self, req: Request, schema: type[Response[R]]) -> R:
-            raise NotImplementedError()  # type: ignore[misc]
+            raise NotImplementedError()
 
         @override
         async def apply_workspace_edit(self, edit: lsp_type.WorkspaceEdit) -> None:

--- a/tests/unit/capability/request/test_code_action.py
+++ b/tests/unit/capability/request/test_code_action.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import contextlib
+from collections.abc import AsyncGenerator
+from typing import Any, override
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from lsp_client.capability.request.code_action import WithRequestCodeAction
+from lsp_client.protocol import CapabilityClientProtocol
+from lsp_client.utils.types import Request, Response, lsp_type
+
+
+class MockCodeActionClient(WithRequestCodeAction, CapabilityClientProtocol):
+    request_mock: AsyncMock
+    apply_workspace_edit_mock: AsyncMock
+    request_execute_command_mock: AsyncMock
+    workspace: MagicMock
+
+    def __init__(self) -> None:
+        self.request_mock = AsyncMock()
+        self.apply_workspace_edit_mock = AsyncMock()
+        self.request_execute_command_mock = AsyncMock()
+        self.workspace = MagicMock()
+        self.workspace.values.return_value = []
+
+    @override
+    async def request[R](self, req: Request, schema: type[Response[R]]) -> R:
+        return await self.request_mock(req, schema)
+
+    @override
+    async def apply_workspace_edit(self, edit: lsp_type.WorkspaceEdit) -> None:
+        await self.apply_workspace_edit_mock(edit)
+
+    async def request_execute_command(
+        self, command: str, arguments: list[Any] | None = None
+    ) -> Any:
+        return await self.request_execute_command_mock(command, arguments)
+
+    @override
+    def get_document_state(self) -> Any: ...
+    @override
+    def get_workspace(self) -> Any:
+        return self.workspace
+
+    @override
+    def get_config_map(self) -> Any: ...
+    @override
+    @classmethod
+    def get_language_config(cls) -> Any: ...
+
+    @override
+    @contextlib.asynccontextmanager
+    async def open_files(self, *args: Any, **kwargs: Any) -> AsyncGenerator[None]:
+        yield
+
+    @override
+    async def write_file(self, *args: Any, **kwargs: Any) -> Any: ...
+    @override
+    async def read_file(self, *args: Any, **kwargs: Any) -> Any: ...
+    @override
+    async def notify(self, *args: Any, **kwargs: Any) -> Any: ...
+
+    @override
+    def as_uri(self, file_path: Any) -> str:
+        return f"file://{file_path}"
+
+
+@pytest.mark.asyncio
+async def test_apply_code_action_command_only() -> None:
+    client = MockCodeActionClient()
+    command = lsp_type.Command(title="Test", command="test.command", arguments=["arg1"])
+
+    await client.apply_code_action(command)
+
+    client.request_execute_command_mock.assert_called_once_with(
+        "test.command", ["arg1"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_apply_code_action_code_action_edit_only() -> None:
+    client = MockCodeActionClient()
+    edit = lsp_type.WorkspaceEdit(changes={"file1": []})
+    action = lsp_type.CodeAction(title="Test", edit=edit)
+
+    await client.apply_code_action(action)
+
+    client.apply_workspace_edit_mock.assert_called_once_with(edit)
+    client.request_execute_command_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_apply_code_action_code_action_command_only() -> None:
+    client = MockCodeActionClient()
+    command = lsp_type.Command(title="Test", command="test.command", arguments=["arg1"])
+    action = lsp_type.CodeAction(title="Test", command=command)
+
+    await client.apply_code_action(action)
+
+    client.apply_workspace_edit_mock.assert_not_called()
+    client.request_execute_command_mock.assert_called_once_with(
+        "test.command", ["arg1"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_apply_code_action_both_edit_and_command() -> None:
+    client = MockCodeActionClient()
+    edit = lsp_type.WorkspaceEdit(changes={"file1": []})
+    command = lsp_type.Command(title="Test", command="test.command", arguments=["arg1"])
+    action = lsp_type.CodeAction(title="Test", edit=edit, command=command)
+
+    await client.apply_code_action(action)
+
+    client.apply_workspace_edit_mock.assert_called_once_with(edit)
+    client.request_execute_command_mock.assert_called_once_with(
+        "test.command", ["arg1"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_apply_code_action_lazy_resolve() -> None:
+    client = MockCodeActionClient()
+    action = lsp_type.CodeAction(title="Test")
+
+    resolved_edit = lsp_type.WorkspaceEdit(changes={"file2": []})
+    resolved_action = lsp_type.CodeAction(title="Test", edit=resolved_edit)
+    client.request_mock.return_value = resolved_action
+
+    await client.apply_code_action(action)
+
+    client.request_mock.assert_called_once()
+    req, _ = client.request_mock.call_args[0]
+    assert isinstance(req, lsp_type.CodeActionResolveRequest)
+
+    client.apply_workspace_edit_mock.assert_called_once_with(resolved_edit)
+
+
+@pytest.mark.asyncio
+async def test_apply_code_action_disabled() -> None:
+    client = MockCodeActionClient()
+    action = lsp_type.CodeAction(
+        title="Test", disabled=lsp_type.CodeActionDisabled(reason="reason")
+    )
+
+    await client.apply_code_action(action)
+
+    client.apply_workspace_edit_mock.assert_not_called()
+    client.request_execute_command_mock.assert_not_called()
+    client.request_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_apply_code_actions_multiple() -> None:
+    client = MockCodeActionClient()
+    action1 = lsp_type.CodeAction(title="Action 1", edit=lsp_type.WorkspaceEdit())
+    action2 = lsp_type.Command(title="Command 2", command="cmd2")
+
+    await client.apply_code_actions([action1, action2])
+
+    client.apply_workspace_edit_mock.assert_called_once()
+    client.request_execute_command_mock.assert_called_once_with("cmd2", None)
+
+
+@pytest.mark.asyncio
+async def test_apply_code_action_missing_execute_command_capability() -> None:
+    class PartialClient(WithRequestCodeAction, CapabilityClientProtocol):
+        apply_workspace_edit_mock: AsyncMock
+
+        def __init__(self) -> None:
+            self.apply_workspace_edit_mock = AsyncMock()
+
+        @override
+        async def request[R](self, req: Request, schema: type[Response[R]]) -> R:
+            raise NotImplementedError()  # type: ignore[misc]
+
+        @override
+        async def apply_workspace_edit(self, edit: lsp_type.WorkspaceEdit) -> None:
+            await self.apply_workspace_edit_mock(edit)
+
+        @override
+        def get_document_state(self) -> Any:
+            raise NotImplementedError()
+
+        @override
+        def get_workspace(self) -> Any:
+            raise NotImplementedError()
+
+        @override
+        def get_config_map(self) -> Any:
+            raise NotImplementedError()
+
+        @override
+        @classmethod
+        def get_language_config(cls) -> Any:
+            raise NotImplementedError()
+
+        @override
+        @contextlib.asynccontextmanager
+        async def open_files(self, *args: Any, **kwargs: Any) -> AsyncGenerator[None]:
+            yield
+
+        @override
+        async def write_file(self, *args: Any, **kwargs: Any) -> Any: ...
+        @override
+        async def read_file(self, *args: Any, **kwargs: Any) -> Any: ...
+        @override
+        async def notify(self, *args: Any, **kwargs: Any) -> Any: ...
+        @override
+        def as_uri(self, file_path: Any) -> str:
+            return ""
+
+    client = PartialClient()
+    command = lsp_type.Command(title="Test", command="test.command")
+
+    with pytest.raises(RuntimeError, match="executeCommand capability not available"):
+        await client.apply_code_action(command)

--- a/tests/unit/capability/request/test_execute_command.py
+++ b/tests/unit/capability/request/test_execute_command.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import contextlib
+from collections.abc import AsyncGenerator
+from typing import Any, override
+from unittest.mock import AsyncMock
+
+import pytest
+
+from lsp_client.capability.request.execute_command import WithRequestExecuteCommand
+from lsp_client.protocol import CapabilityClientProtocol
+from lsp_client.utils.types import Request, Response, lsp_type
+
+
+class MockClient(WithRequestExecuteCommand, CapabilityClientProtocol):
+    request_mock: AsyncMock
+
+    def __init__(self) -> None:
+        self.request_mock = AsyncMock()
+
+    @override
+    async def request[R](self, req: Request, schema: type[Response[R]]) -> R:
+        return await self.request_mock(req, schema)
+
+    @override
+    def get_document_state(self) -> Any: ...
+    @override
+    def get_workspace(self) -> Any: ...
+    @override
+    def get_config_map(self) -> Any: ...
+    @override
+    @classmethod
+    def get_language_config(cls) -> Any: ...
+
+    @override
+    @contextlib.asynccontextmanager
+    async def open_files(self, *args: Any, **kwargs: Any) -> AsyncGenerator[None]:
+        yield
+
+    @override
+    async def write_file(self, *args: Any, **kwargs: Any) -> Any: ...
+    @override
+    async def read_file(self, *args: Any, **kwargs: Any) -> Any: ...
+    @override
+    async def notify(self, *args: Any, **kwargs: Any) -> Any: ...
+
+
+@pytest.mark.asyncio
+async def test_request_execute_command() -> None:
+    client = MockClient()
+    client.request_mock.return_value = "command_result"
+
+    result = await client.request_execute_command("test.command", ["arg1", 42])
+
+    assert result == "command_result"
+    client.request_mock.assert_called_once()
+    req, schema = client.request_mock.call_args[0]
+
+    assert isinstance(req, lsp_type.ExecuteCommandRequest)
+    assert req.method == lsp_type.WORKSPACE_EXECUTE_COMMAND
+    assert req.params.command == "test.command"
+    assert req.params.arguments == ["arg1", 42]
+    assert schema == lsp_type.ExecuteCommandResponse
+
+
+def test_execute_command_capability_check() -> None:
+    class TestClient(WithRequestExecuteCommand):
+        @override
+        def get_document_state(self) -> Any: ...
+        @override
+        def get_workspace(self) -> Any: ...
+        @override
+        def get_config_map(self) -> Any: ...
+        @override
+        @classmethod
+        def get_language_config(cls) -> Any: ...
+        @override
+        @contextlib.asynccontextmanager
+        async def open_files(self, *args: Any, **kwargs: Any) -> AsyncGenerator[None]:
+            yield
+
+        @override
+        async def request(self, *args: Any, **kwargs: Any) -> Any: ...
+        @override
+        async def notify(self, *args: Any, **kwargs: Any) -> Any: ...
+        @override
+        async def read_file(self, *args: Any, **kwargs: Any) -> Any: ...
+        @override
+        async def write_file(self, *args: Any, **kwargs: Any) -> Any: ...
+
+    caps = lsp_type.ServerCapabilities(
+        execute_command_provider=lsp_type.ExecuteCommandOptions(commands=["cmd"])
+    )
+    TestClient.check_server_capability(caps)
+
+    caps = lsp_type.ServerCapabilities(execute_command_provider=None)
+    with pytest.raises(AssertionError):
+        TestClient.check_server_capability(caps)


### PR DESCRIPTION
## Summary
- Introduced a new utility module `lsp_client.utils.install` with generic helpers for installing language servers via commands or scripts.
- Refactored multiple language clients (`pyright`, `deno`, `gopls`, `rust-analyzer`, etc.) to use these shared helpers, reducing code duplication and improving consistency.
- Enhanced cross-platform support for installation scripts (supporting Bash/Sh on Unix and PowerShell/Cmd on Windows).
- Improved error messages and reporting during the automatic installation process.