### PR TITLE
Fix parsing of requests containing extra headers; always send Content-Type header in responses.

### DIFF
--- a/src/lsp_client/jsonrpc/parse.py
+++ b/src/lsp_client/jsonrpc/parse.py
@@ -10,22 +10,21 @@ from .convert import package_serialize
 from .exception import JsonRpcParseError, JsonRpcTransportError
 from .types import RawPackage
 
-HEADER_RE = re.compile(r"Content-Length:\s*(?P<length>\d+)")
+CONTENT_LENGTH_HEADER_RE = re.compile(r"Content-Length:\s*(?P<length>\d+)")
 """match lsp header line: `Content-Length: ...\r\n`"""
 
 
 async def read_raw_package(receiver: BufferedByteReceiveStream) -> RawPackage:
     # when process is closed, the reader will always return b''
-    header_bytes = await receiver.receive_until(b"\r\n", max_bytes=65536)
+    header_bytes = await receiver.receive_until(b"\r\n\r\n", max_bytes=65536)
     if not header_bytes:
         raise JsonRpcTransportError("LSP server process closed")
 
     header = header_bytes.decode("utf-8")
-    header_match = HEADER_RE.match(header)
-    if not header_match or not (length := int(header_match.group("length"))):
-        raise JsonRpcParseError("Invalid LSP response header")
-
-    await receiver.receive_until(b"\r\n", max_bytes=65536)  # consume '\r\n'
+    if header_match := CONTENT_LENGTH_HEADER_RE.search(header):
+        length = int(header_match.group("length"))
+    else:
+        raise JsonRpcParseError("Missing Content-Length header")
 
     body_bytes = await receiver.receive_exactly(length)
     return json.loads(body_bytes.decode("utf-8"))
@@ -35,5 +34,5 @@ async def write_raw_package(sender: AnyByteSendStream, package: RawPackage) -> N
     dumped = package_serialize(package).encode("utf-8")
     length = len(dumped)
 
-    header = f"Content-Length: {length}\r\n\r\n".encode()
-    await sender.send(header + dumped)
+    headers = f"Content-Type: application/vscode-jsonrpc; charset=utf-8\r\nContent-Length: {length}\r\n\r\n".encode()
+    await sender.send(headers + dumped)

--- a/src/lsp_client/server/abc.py
+++ b/src/lsp_client/server/abc.py
@@ -13,6 +13,7 @@ from anyio.streams.buffered import BufferedByteReceiveStream
 from attrs import define, field
 from loguru import logger
 
+from lsp_client.jsonrpc import JsonRpcTransportError
 from lsp_client.jsonrpc.channel import ResponseTable, response_channel
 from lsp_client.jsonrpc.parse import read_raw_package, write_raw_package
 from lsp_client.jsonrpc.types import (
@@ -152,7 +153,7 @@ class StreamServer(Server):
         try:
             package = await read_raw_package(self._buffered_receive_stream)
             logger.debug("Received package: {}", package)
-        except (anyio.EndOfStream, anyio.IncompleteRead, anyio.ClosedResourceError):
+        except (anyio.EndOfStream, anyio.IncompleteRead, anyio.ClosedResourceError, JsonRpcTransportError):
             logger.debug("Stream closed")
             return None
         else:

--- a/tests/unit/test_jsonrpc/test_parse.py
+++ b/tests/unit/test_jsonrpc/test_parse.py
@@ -16,14 +16,14 @@ async def test_read_raw_package():
     mock_receiver = AsyncMock(spec=BufferedByteReceiveStream)
 
     # Mock header
-    mock_receiver.receive_until.side_effect = [b"Content-Length: 18\r\n", b"\r\n"]
+    mock_receiver.receive_until.return_value = b"Content-Length: 18\r\n\r\n"
     # Mock body
     body = {"test": "data"}
     mock_receiver.receive_exactly.return_value = json.dumps(body).encode("utf-8")
 
     result = await read_raw_package(mock_receiver)
     assert result == body
-    assert mock_receiver.receive_until.call_count == 2
+    mock_receiver.receive_until.assert_called_once_with(b"\r\n\r\n", max_bytes=65536)
     mock_receiver.receive_exactly.assert_called_once_with(18)
 
 
@@ -39,9 +39,9 @@ async def test_read_raw_package_closed():
 @pytest.mark.asyncio
 async def test_read_raw_package_invalid_header():
     mock_receiver = AsyncMock(spec=BufferedByteReceiveStream)
-    mock_receiver.receive_until.return_value = b"Invalid-Header\r\n"
+    mock_receiver.receive_until.return_value = b"Invalid-Header\r\n\r\n"
 
-    with pytest.raises(JsonRpcParseError, match="Invalid LSP response header"):
+    with pytest.raises(JsonRpcParseError, match="Missing Content-Length header"):
         await read_raw_package(mock_receiver)
 
 
@@ -57,3 +57,43 @@ async def test_write_raw_package():
     expected = f"Content-Length: {len(dumped)}\r\n\r\n".encode() + dumped
 
     mock_sender.send.assert_called_once_with(expected)
+
+
+@pytest.mark.asyncio
+async def test_read_raw_package_with_extra_headers():
+    mock_receiver = AsyncMock(spec=BufferedByteReceiveStream)
+
+    # Mock headers: Content-Type followed by Content-Length
+    mock_receiver.receive_until.return_value = (
+        b"Content-Type: application/vscode-jsonrpc; charset=utf-8\r\n"
+        b"Content-Length: 18\r\n"
+        b"\r\n"
+    )
+    # Mock body
+    body = {"test": "data"}
+    mock_receiver.receive_exactly.return_value = json.dumps(body).encode("utf-8")
+
+    result = await read_raw_package(mock_receiver)
+    assert result == body
+    mock_receiver.receive_until.assert_called_once_with(b"\r\n\r\n", max_bytes=65536)
+    mock_receiver.receive_exactly.assert_called_once_with(18)
+
+
+@pytest.mark.asyncio
+async def test_read_raw_package_with_extra_headers_reversed():
+    mock_receiver = AsyncMock(spec=BufferedByteReceiveStream)
+
+    # Mock headers: Content-Length followed by Content-Type
+    mock_receiver.receive_until.return_value = (
+        b"Content-Length: 18\r\n"
+        b"Content-Type: application/vscode-jsonrpc; charset=utf-8\r\n"
+        b"\r\n"
+    )
+    # Mock body
+    body = {"test": "data"}
+    mock_receiver.receive_exactly.return_value = json.dumps(body).encode("utf-8")
+
+    result = await read_raw_package(mock_receiver)
+    assert result == body
+    mock_receiver.receive_until.assert_called_once_with(b"\r\n\r\n", max_bytes=65536)
+    mock_receiver.receive_exactly.assert_called_once_with(18)


### PR DESCRIPTION
## Summary
Fixed issue #84

## Type of Change
- [ ] 🚀 Feature
- [*] 🐛 Bug Fix
- [ ] 📖 Documentation
- [ ] ⚙️ Refactoring
- [ ] 🔧 Maintenance
- [ ] 🧪 Testing

## Checklist
- [*] I have followed the project's code style (ruff, ty)
- [*] I have added tests that prove my fix is effective or that my feature works
- [*] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation (if applicable)
